### PR TITLE
Replace branded logos with black placeholders

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -30,7 +30,9 @@ select.input{appearance:none;background:rgba(255,255,255,.82);background-image:l
 
 <header class="header">
   <div class="container header-inner">
-    <div class="logo"><img src="assets/logo.svg" alt="Capital Connect LK logo" class="logo-image"><span class="logo-wordmark"><span class="wordmark-text">Capital Connect</span><span class="accent">LK</span></span></div>
+    <div class="logo">
+      <span class="logo-placeholder" role="img" aria-label="Capital Connect LK"></span>
+    </div>
     <nav>
       <a href="index.html#revenue">Revenue Share</a>
       <a href="index.html#problems">Why Us</a>
@@ -45,7 +47,9 @@ select.input{appearance:none;background:rgba(255,255,255,.82);background-image:l
   <div class="container" style="max-width:760px">
     <div class="form-wrap">
       <div class="form-head">
-        <div class="logo" style="gap:.4rem"><img src="assets/logo.svg" alt="Capital Connect LK logo" class="logo-image"><span class="logo-wordmark"><span class="wordmark-text">Capital Connect</span><span class="accent">LK</span></span></div>
+        <div class="logo">
+          <span class="logo-placeholder" role="img" aria-label="Capital Connect LK"></span>
+        </div>
         <a class="btn small" href="#">Start Intake</a>
       </div>
       <div class="form-body">
@@ -100,8 +104,7 @@ select.input{appearance:none;background:rgba(255,255,255,.82);background-image:l
 <footer id="footer" class="footer">
   <div class="container inner">
     <div class="logo">
-      <img src="assets/logo.svg" alt="Capital Connect LK logo" class="logo-image">
-      <span class="logo-wordmark"><span class="wordmark-text">Capital Connect</span><span class="accent">LK</span></span>
+      <span class="logo-placeholder" role="img" aria-label="Capital Connect LK"></span>
     </div>
     <div>A Zero Risk, Zero Cost, Turnkey Solution.</div>
     <div>Email: <a href="mailto:hello@capitalconnectlk.info">info@rooftopmoney.com</a></div>

--- a/index.html
+++ b/index.html
@@ -13,8 +13,7 @@
 <header class="header">
   <div class="container header-inner">
     <div class="logo">
-      <img src="assets/logo.svg" alt="Capital Connect LK logo" class="logo-image">
-      <span class="logo-wordmark"><span class="wordmark-text">Capital Connect</span><span class="accent">LK</span></span>
+      <span class="logo-placeholder" role="img" aria-label="Capital Connect LK"></span>
     </div>
     <nav>
       <a href="#revenue">Fees</a>
@@ -216,8 +215,7 @@
 <footer id="footer" class="footer">
   <div class="container inner">
     <div class="logo">
-      <img src="assets/logo.svg" alt="Capital Connect LK logo" class="logo-image">
-      <span class="logo-wordmark"><span class="wordmark-text">Capital Connect</span><span class="accent">LK</span></span>
+      <span class="logo-placeholder" role="img" aria-label="Capital Connect LK"></span>
     </div>
     <div>Curated introductions. No upfront fees.</div>
     <div>Email: <a href="mailto:hello@capitalconnectlk.info">hello@capitalconnectlk.info</a></div>

--- a/styles.css
+++ b/styles.css
@@ -47,12 +47,8 @@ img{max-width:100%;display:block}
   backdrop-filter:saturate(180%) blur(28px);
 }
 .header-inner{display:flex;align-items:center;justify-content:space-between; padding:.85rem 1.2rem; gap:1.4rem}
-.logo{display:flex;align-items:center;gap:.7rem;font-weight:700;letter-spacing:.2px;font-size:1.05rem}
-.logo-image{width:32px;height:32px;border-radius:10px;box-shadow:0 10px 22px rgba(15,23,42,.24);display:block}
-.logo-wordmark{display:flex;align-items:center;gap:.35rem}
-.logo-wordmark .wordmark-text{white-space:nowrap}
-.logo-wordmark .accent{color:var(--brand)}
-.footer .logo-wordmark .accent{color:#9ee7c3}
+.logo{display:flex;align-items:center}
+.logo-placeholder{width:32px;height:32px;border-radius:10px;background:#000;box-shadow:0 10px 22px rgba(15,23,42,.24);display:block}
 .btn{display:inline-flex;align-items:center;gap:.5rem;
   background:var(--cta);color:var(--cta-ink);border-radius:999px;padding:.72rem 1.2rem;
   font-weight:600; box-shadow:0 18px 28px rgba(10,132,255,.28), 0 0 0 1px rgba(255,255,255,.3) inset;


### PR DESCRIPTION
## Summary
- remove the logo image and wordmark markup from the index and contact pages
- introduce a reusable black placeholder block so branding appears as a neutral box

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9c4b733fc832593c0ab1ddf10b327