### PR TITLE
Remove progress bar indicator from contact form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -84,7 +84,6 @@ select.input{appearance:none;background:rgba(255,255,255,.82);background-image:l
         </div>
 
         <div class="bar-note">33%</div>
-        <div class="progress"><i></i></div>
 
         <div class="cta-row mt-2">
           <button class="btn small" id="next">Next</button>


### PR DESCRIPTION
## Summary
- remove the progress bar element from the contact intake form

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9d88724648325ab705d5a2ec2ebcc