### PR TITLE
Refine fees section layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,47 +68,33 @@
 
 <section id="fees" class="section">
   <div class="container">
-    <div class="center">
-      <h2>Our Fees Model Is Simple.</h2>
+    <div class="fees-head">
+      <div>
+        <span class="eyebrow">Fees</span>
+        <h2>Our Fees Model Is Simple.</h2>
+      </div>
       <p class="caption">Average raise sizes we work with: <strong>LKR 2M – 50M</strong></p>
     </div>
 
-    <div class="card mt-2">
-      <div class="meter" title="Rooftop Size">
-        <div class="dot" style="left:33%"></div>
-      </div>
-      <div class="pricing-grid">
-        <div class="pricing-card">
-          <div class="pricing-header">
-            <span class="badge small">Model A</span>
-            <h3>Kick-off Tier</h3>
-          </div>
-          <p>
-            <strong>5%</strong> on the first <strong>LKR 10M</strong><br>
-            Ideal for early traction rounds and angel-led raises.
-          </p>
-        </div>
-        <div class="pricing-card">
-          <div class="pricing-header">
-            <span class="badge small">Model B</span>
-            <h3>Tiered Upside</h3>
-          </div>
-          <p>
-            <strong>3%</strong> on the next <strong>LKR 40M</strong><br>
-            Keeps momentum as you scale conversations with larger cheques.
-          </p>
-        </div>
-        <div class="pricing-card">
-          <div class="pricing-header">
-            <span class="badge small">Model C</span>
-            <h3>Enterprise Wrap</h3>
-          </div>
-          <p>
-            <strong>1%</strong> above <strong>LKR 50M</strong><br>
-            Aligns for expansion or strategic capital beyond the core round.
-          </p>
-        </div>
-      </div>
+    <div class="fees-grid">
+      <article class="fee-card is-primary">
+        <span class="fee-label">Model A</span>
+        <h3>Kick-off Tier</h3>
+        <p class="fee-rate"><strong>5%</strong> on the first <strong>LKR 10M</strong></p>
+        <p class="caption">Ideal for early traction rounds and angel-led raises.</p>
+      </article>
+      <article class="fee-card">
+        <span class="fee-label">Model B</span>
+        <h3>Tiered Upside</h3>
+        <p class="fee-rate"><strong>3%</strong> on the next <strong>LKR 40M</strong></p>
+        <p class="caption">Keeps momentum as you scale conversations with larger cheques.</p>
+      </article>
+      <article class="fee-card">
+        <span class="fee-label">Model C</span>
+        <h3>Enterprise Wrap</h3>
+        <p class="fee-rate"><strong>1%</strong> above <strong>LKR 50M</strong></p>
+        <p class="caption">Aligns for expansion or strategic capital beyond the core round.</p>
+      </article>
     </div>
 
     <div class="banner mt-3" id="cta">

--- a/styles.css
+++ b/styles.css
@@ -94,25 +94,22 @@ h1{font-size:clamp(2.1rem, 2.6vw + 1.4rem, 3.2rem);line-height:1.08;margin:.6rem
 .center{text-align:center}
 h2{font-size:clamp(1.4rem, 1.3vw + 1.2rem, 2.1rem); margin:0 0 .85rem;font-weight:650;letter-spacing:-.01em}
 .kpis{display:grid;grid-template-columns:repeat(2,1fr);gap:1rem;margin-top:1.4rem}
+.fees-head{display:flex;align-items:flex-end;justify-content:space-between;gap:1.4rem;flex-wrap:wrap;margin-bottom:1.8rem}
+.eyebrow{text-transform:uppercase;letter-spacing:.18em;font-size:.76rem;font-weight:650;color:rgba(15,23,42,.55);display:inline-block;margin-bottom:.65rem}
+.fees-head h2{margin:0}
+.fees-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:1.4rem}
+.fee-card{position:relative;display:grid;gap:.55rem;padding:1.8rem;border-radius:22px;background:linear-gradient(160deg,rgba(255,255,255,.82),rgba(255,255,255,.55));border:1px solid rgba(255,255,255,.6);box-shadow:0 24px 46px rgba(15,23,42,.12);backdrop-filter:blur(26px);transition:transform .35s ease, box-shadow .35s ease, border-color .35s ease}
+.fee-card::after{content:"";position:absolute;inset:auto 18px -18px 18px;height:1px;background:linear-gradient(90deg,transparent,rgba(255,255,255,.85),transparent);opacity:.5}
+.fee-card:hover{transform:translateY(-4px);box-shadow:0 36px 64px rgba(10,20,60,.18);border-color:rgba(10,132,255,.3)}
+.fee-card.is-primary{background:linear-gradient(150deg,rgba(10,132,255,.16),rgba(255,255,255,.86));border-color:rgba(10,132,255,.42);box-shadow:0 34px 62px rgba(10,132,255,.22)}
 .card{border-radius:var(--radius);padding:1.2rem;position:relative;overflow:hidden;background:var(--card);backdrop-filter:saturate(180%) blur(24px);border:1px solid var(--glass-border);box-shadow:var(--shadow);transition:transform .4s ease, box-shadow .4s ease;}
 .card::after{content:"";position:absolute;inset:auto 18px -28px 18px;height:1px;background:linear-gradient(90deg,transparent,rgba(255,255,255,.7),transparent);opacity:.4}
 .card:hover{transform:translateY(-4px);box-shadow:0 40px 80px rgba(10,20,60,.18)}
-.meter{height:6px;background:rgba(10,20,60,.08);border-radius:999px;position:relative;margin:.8rem 0 1rem;overflow:hidden}
-.meter .dot{width:14px;height:14px;border-radius:50%;background:var(--brand);position:absolute;top:50%;transform:translate(-50%,-50%);left:33%}
-.model{display:grid;grid-template-columns:1fr 1fr;gap:1rem}
-.model .tile{background:linear-gradient(135deg,rgba(255,255,255,.7),rgba(255,255,255,.45));border:1px solid rgba(255,255,255,.55);border-radius:16px;padding:1rem;box-shadow:0 22px 40px rgba(15,23,42,.08);backdrop-filter:blur(26px);}
-.tile h3{margin:.1rem 0 .4rem;font-size:1rem}
-.tile p{color:var(--muted);font-size:.96rem;margin:0}
-
-.pricing-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:1.2rem;margin-top:1.2rem}
-.pricing-card{position:relative;overflow:hidden;border-radius:18px;padding:1.4rem;background:linear-gradient(160deg,rgba(255,255,255,.78),rgba(255,255,255,.42));border:1px solid rgba(255,255,255,.55);box-shadow:0 26px 44px rgba(10,20,60,.14);backdrop-filter:blur(28px);transition:transform .45s cubic-bezier(.25,.8,.25,1),box-shadow .45s, border-color .45s;animation:floatCard 9s ease-in-out infinite;}
-.pricing-card::before{content:"";position:absolute;inset:auto -20% -40% -20%;height:40%;background:radial-gradient(circle at 50% 0,rgba(90,200,250,.35),transparent 70%);opacity:.7;filter:blur(12px);pointer-events:none}
-.pricing-card:nth-child(2){animation-delay:-1.4s}
-.pricing-card:nth-child(3){animation-delay:-2.8s}
-.pricing-card:hover{transform:translateY(-6px);box-shadow:0 40px 70px rgba(10,20,60,.2);border-color:rgba(10,132,255,.45)}
-.pricing-card p{margin:.8rem 0 0;color:var(--muted);font-size:.95rem}
-.pricing-header{display:flex;flex-direction:column;gap:.45rem}
-.badge.small{font-size:.9rem;padding:.32rem .8rem}
+.fee-label{display:inline-flex;align-items:center;gap:.35rem;padding:.35rem .85rem;border-radius:999px;background:rgba(10,132,255,.12);color:#0a84ff;font-weight:600;font-size:.88rem;letter-spacing:.02em}
+.fee-card h3{margin:0;font-size:1.18rem;letter-spacing:-.01em}
+.fee-rate{margin:.15rem 0 0;font-size:1.05rem;font-weight:550;color:var(--ink)}
+.fee-rate strong{font-size:1.15em}
+.fee-card .caption{margin-top:.4rem}
 
 /* banner */
 .banner{border-radius:28px; overflow:hidden; position:relative; color:#fff;background:linear-gradient(135deg,rgba(10,20,60,.85),rgba(10,132,255,.8));box-shadow:0 40px 70px rgba(10,20,60,.32);}
@@ -157,11 +154,14 @@ h2{font-size:clamp(1.4rem, 1.3vw + 1.2rem, 2.1rem); margin:0 0 .85rem;font-weigh
 hr.sep{border:0;border-top:1px solid #e6eaee;margin:1.75rem 0}
 
 /* responsive */
+@media (max-width: 1040px){
+  .fees-grid{grid-template-columns:repeat(2,minmax(0,1fr));}
+}
 @media (max-width: 920px){
   .header{top:12px}
   .hero{padding:4.5rem 0 2.6rem}
-  .hero .grid, .model, .about{grid-template-columns:1fr}
-  .pricing-grid{grid-template-columns:1fr;}
+  .hero .grid, .about{grid-template-columns:1fr}
+  .fees-grid{grid-template-columns:1fr;}
   .kpis{grid-template-columns:1fr}
   .problems{grid-template-columns:repeat(2,1fr)}
   .grid-2{grid-template-columns:1fr}


### PR DESCRIPTION
## Summary
- restyle the fees section with a dedicated header and simplified three-card layout
- refresh Model A/B/C pricing cards with clearer labels and improved readability
- add responsive rules for the new grid while keeping existing cards intact elsewhere

## Testing
- Not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d9dafbd3b08325ac246e0e7d7d3a93