### PR TITLE
Add Capital Connect LK branding to header and footer

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -32,6 +32,7 @@ select.input{appearance:none;background:rgba(255,255,255,.82);background-image:l
   <div class="container header-inner">
     <div class="logo">
       <span class="logo-placeholder" role="img" aria-label="Capital Connect LK"></span>
+      <span class="site-title">Capital Connect LK</span>
     </div>
     <nav>
       <a href="index.html#revenue">Revenue Share</a>
@@ -49,6 +50,7 @@ select.input{appearance:none;background:rgba(255,255,255,.82);background-image:l
       <div class="form-head">
         <div class="logo">
           <span class="logo-placeholder" role="img" aria-label="Capital Connect LK"></span>
+          <span class="site-title">Capital Connect LK</span>
         </div>
         <a class="btn small" href="#">Start Intake</a>
       </div>
@@ -105,11 +107,12 @@ select.input{appearance:none;background:rgba(255,255,255,.82);background-image:l
   <div class="container inner">
     <div class="logo">
       <span class="logo-placeholder" role="img" aria-label="Capital Connect LK"></span>
+      <span class="site-title">Capital Connect LK</span>
     </div>
-    <div>A Zero Risk, Zero Cost, Turnkey Solution.</div>
-    <div>Email: <a href="mailto:hello@capitalconnectlk.info">info@rooftopmoney.com</a></div>
-    <div><a class="btn small" href="#">Start Intake</a></div>
-    <div class="caption">© 2025 RooftopMoney. All rights reserved.</div>
+    <div>Curated introductions. No upfront fees.</div>
+    <div>Email: <a href="mailto:hello@capitalconnectlk.info">hello@capitalconnectlk.info</a></div>
+    <div><a class="btn small" href="contact.html">Start Intake</a></div>
+    <div class="caption">Capital Connect LK is a marketing & introductions program. We don’t provide investment advice, arrange investments, or handle client funds. No promises of funding or returns. © 2025 Capital Connect LK.</div>
   </div>
 </footer>
 

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   <div class="container header-inner">
     <div class="logo">
       <span class="logo-placeholder" role="img" aria-label="Capital Connect LK"></span>
+      <span class="site-title">Capital Connect LK</span>
     </div>
     <nav>
       <a href="#revenue">Fees</a>
@@ -236,6 +237,7 @@
   <div class="container inner">
     <div class="logo">
       <span class="logo-placeholder" role="img" aria-label="Capital Connect LK"></span>
+      <span class="site-title">Capital Connect LK</span>
     </div>
     <div>Curated introductions. No upfront fees.</div>
     <div>Email: <a href="mailto:hello@capitalconnectlk.info">hello@capitalconnectlk.info</a></div>

--- a/styles.css
+++ b/styles.css
@@ -47,8 +47,9 @@ img{max-width:100%;display:block}
   backdrop-filter:saturate(180%) blur(28px);
 }
 .header-inner{display:flex;align-items:center;justify-content:space-between; padding:.85rem 1.2rem; gap:1.4rem}
-.logo{display:flex;align-items:center}
+.logo{display:flex;align-items:center;gap:.65rem;font-weight:700;letter-spacing:-.01em;color:var(--ink)}
 .logo-placeholder{width:32px;height:32px;border-radius:10px;background:#000;box-shadow:0 10px 22px rgba(15,23,42,.24);display:block}
+.site-title{font-size:1.05rem}
 .btn{display:inline-flex;align-items:center;gap:.5rem;
   background:var(--cta);color:var(--cta-ink);border-radius:999px;padding:.72rem 1.2rem;
   font-weight:600; box-shadow:0 18px 28px rgba(10,132,255,.28), 0 0 0 1px rgba(255,255,255,.3) inset;
@@ -149,6 +150,7 @@ h2{font-size:clamp(1.4rem, 1.3vw + 1.2rem, 2.1rem); margin:0 0 .85rem;font-weigh
 .footer a{color:#64d2ff}
 .footer .inner{padding:2.6rem 0;display:grid;gap:.9rem;position:relative}
 .footer .caption{color:#fff}
+.footer .logo{color:#e1e7ff}
 
 /* utilities */
 .grid-2{display:grid;grid-template-columns:1.2fr .8fr; gap:1.4rem}


### PR DESCRIPTION
## Summary
- add the Capital Connect LK site title beside the logo in headers and footers
- align contact page footer content with the Capital Connect LK branding
- style the logo container to support the new title in both light and dark sections

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9dc68c0748325a5a2f0b74042f76d