### PR TITLE
Refresh about section highlight layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,54 +168,73 @@
 
 <section id="about" class="section">
   <div class="container about">
-    <div>
+    <div class="about-main">
       <h2>Built for Sri Lankan Founders, With Investor-Grade Discipline.</h2>
       <p class="caption">Capital Connect LK is a <strong>marketing & introductions program</strong> focused on Sri Lanka. We keep the process private, consent-first, and auditable—so founders save time and investors see only relevant opportunities.</p>
-      
-<div class="grid-2 mt-2">
-  <div class="feature">
-    <strong>No Upfront Fees</strong>
-    <div class="shot"></div>
-    <p class="caption">Pay only on a closed investment from our introduction.</p>
-  </div>
-  <div class="feature">
-    <strong>Curated Intros</strong>
-    <div class="shot"></div>
-    <p class="caption">We match by sector, stage, cheque size, and thesis.</p>
-  </div>
-  <div class="feature">
-    <strong>Privacy & PDPA</strong>
-    <div class="shot"></div>
-    <p class="caption">Opt-in sharing, retention limits, and a clear access/deletion path.</p>
-  </div>
-  <div class="feature">
-    <strong>Transparent Terms</strong>
-    <div class="shot"></div>
-    <p class="caption">Clear attribution window. Exclude your pre-existing investors.</p>
-  </div>
-  <div class="feature">
-    <strong>Fast Turnaround</strong>
-    <div class="shot"></div>
-    <p class="caption">Most intros happen within <strong>7 days</strong> of a complete intake.</p>
-  </div>
-  <div class="feature">
-    <strong>Neutral & Compliant</strong>
-    <div class="shot"></div>
-    <p class="caption">We don’t advise, arrange, or handle funds—just introductions.</p>
-  </div>
-</div>
-</div>
-<div class="card">
 
-      <h3 style="margin-top:0">Ready to begin?</h3>
+      <div class="about-badges">
+        <span class="pill">Success-only Fees</span>
+        <span class="pill">Sri Lanka Focus</span>
+        <span class="pill">Audit Trail Included</span>
+      </div>
+
+      <div class="about-grid">
+        <article class="about-feature">
+          <span class="feature-icon">💸</span>
+          <div>
+            <h3>No Upfront Fees</h3>
+            <p class="caption">Pay us only when a qualifying investor we introduced actually funds your round.</p>
+          </div>
+        </article>
+        <article class="about-feature">
+          <span class="feature-icon">🤝</span>
+          <div>
+            <h3>Curated Intros</h3>
+            <p class="caption">Warm introductions filtered by sector fit, cheque size, and investor thesis.</p>
+          </div>
+        </article>
+        <article class="about-feature">
+          <span class="feature-icon">🔒</span>
+          <div>
+            <h3>Privacy &amp; PDPA</h3>
+            <p class="caption">Consent-based data sharing with retention controls and a clear deletion path.</p>
+          </div>
+        </article>
+        <article class="about-feature">
+          <span class="feature-icon">📜</span>
+          <div>
+            <h3>Transparent Terms</h3>
+            <p class="caption">Explicit attribution windows and the ability to exclude existing investors.</p>
+          </div>
+        </article>
+        <article class="about-feature">
+          <span class="feature-icon">⚡</span>
+          <div>
+            <h3>Fast Turnaround</h3>
+            <p class="caption">Most vetted introductions go out within <strong>7 days</strong> of completing intake.</p>
+          </div>
+        </article>
+        <article class="about-feature">
+          <span class="feature-icon">⚖️</span>
+          <div>
+            <h3>Neutral &amp; Compliant</h3>
+            <p class="caption">We simply facilitate intros—no advising, arranging, or handling of funds.</p>
+          </div>
+        </article>
+      </div>
+    </div>
+
+    <aside class="about-side card">
+      <h3>Ready to begin?</h3>
+      <p class="caption">Here’s what happens once you share your round details.</p>
       <ul class="mt-1">
-        <li>Site study, financial model, and risk‑free proposal.</li>
-        <li>Full‑service EPC delivery and interconnection.</li>
-        <li>Audit trail with timestamped introductions.</li>
-        <li>Simple revenue‑share with direct payments.</li>
+        <li>Investor-ready summary crafted from your intake.</li>
+        <li>Soft commit verification and identity checks.</li>
+        <li>Timestamped audit trail for every introduction.</li>
+        <li>Success-only fee invoiced post investment.</li>
       </ul>
       <a href="contact.html" class="btn mt-2">Start Intake</a>
-    </div>
+    </aside>
   </div>
 </section>
 

--- a/styles.css
+++ b/styles.css
@@ -136,10 +136,18 @@ h2{font-size:clamp(1.4rem, 1.3vw + 1.2rem, 2.1rem); margin:0 0 .85rem;font-weigh
 .bullet{width:32px;height:32px;border-radius:50%;background:linear-gradient(135deg,#0A84FF,#5AC8FA);display:grid;place-items:center;color:#fff;font-weight:700;box-shadow:0 12px 24px rgba(10,132,255,.28)}
 
 /* about */
-.about{display:grid;grid-template-columns:1fr 1fr; gap:1.4rem}
-.about .grid-2{display:grid;grid-template-columns:1fr 1fr; gap:1.1rem}
-.feature{display:grid;gap:.35rem;background:linear-gradient(135deg,rgba(255,255,255,.72),rgba(255,255,255,.5));padding:1rem;border-radius:18px;border:1px solid rgba(255,255,255,.5);backdrop-filter:blur(20px);box-shadow:0 20px 32px rgba(15,23,42,.12)}
-.feature .shot{aspect-ratio:4/3;border-radius:14px;background:linear-gradient(135deg,rgba(10,132,255,.15),rgba(255,255,255,.6));border:1px solid rgba(255,255,255,.6);box-shadow:inset 0 1px 0 rgba(255,255,255,.4),0 10px 24px rgba(15,23,42,.12)}
+.about{display:grid;grid-template-columns:1.1fr .9fr; gap:1.6rem;align-items:start}
+.about-main{display:grid;gap:1.5rem}
+.about-badges{display:flex;flex-wrap:wrap;gap:.6rem}
+.pill{display:inline-flex;align-items:center;gap:.4rem;padding:.45rem .9rem;border-radius:999px;background:rgba(10,132,255,.14);border:1px solid rgba(10,132,255,.18);color:#0a5fd4;font-weight:600;font-size:.85rem;box-shadow:0 12px 24px rgba(10,132,255,.15)}
+.about-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:1.2rem}
+.about-feature{display:flex;gap:1rem;align-items:flex-start;padding:1.2rem;border-radius:20px;background:linear-gradient(140deg,rgba(255,255,255,.78),rgba(255,255,255,.48));border:1px solid rgba(255,255,255,.55);backdrop-filter:blur(22px);box-shadow:0 26px 46px rgba(15,23,42,.14);transition:transform .35s ease, box-shadow .35s ease}
+.about-feature:hover{transform:translateY(-4px);box-shadow:0 34px 58px rgba(10,20,60,.18)}
+.about-feature h3{margin:0;font-size:1.05rem;letter-spacing:-.01em}
+.feature-icon{width:46px;height:46px;border-radius:16px;display:grid;place-items:center;font-size:1.3rem;background:linear-gradient(135deg,rgba(10,132,255,.22),rgba(90,200,250,.22));border:1px solid rgba(10,132,255,.28);box-shadow:0 12px 26px rgba(10,132,255,.18)}
+.about-side{position:sticky;top:6.5rem;display:grid;gap:1rem;padding:2rem}
+.about-side h3{margin:0;font-size:1.35rem}
+.about-side .caption{color:rgba(15,23,42,.75)}
 
 /* footer */
 .footer{background:rgba(10,20,60,.9);color:#e1e7ff;margin-top:3rem;position:relative;overflow:hidden}
@@ -168,6 +176,8 @@ hr.sep{border:0;border-top:1px solid #e6eaee;margin:1.75rem 0}
   .problems{grid-template-columns:repeat(2,1fr)}
   .grid-2{grid-template-columns:1fr}
   .banner-inner{padding:2rem}
+  .about-side{position:static;padding:1.6rem}
+  .about-grid{grid-template-columns:1fr}
 }
 @media (max-width: 520px){
   .header{width:calc(100% - 1.6rem)}


### PR DESCRIPTION
## Summary
- redesign the about section to feature a modern badge row and gradient highlight cards
- update the supporting call-to-action copy to match the investor introduction workflow
- add styling for the new layout, including responsive tweaks

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9dde241208325ad582579fc1c829b