### PR TITLE
Replace problem section icons with custom SVGs

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,22 +116,47 @@
       <hr class="sep">
       <div class="problems">
         <div class="pi">
-          <div class="ic">🏢</div>
+          <div class="ic" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+              <rect x="6" y="3" width="12" height="18" rx="2" fill="#0B0B0B"></rect>
+              <rect x="9" y="6" width="6" height="12" rx="1" fill="#FFFFFF"></rect>
+              <circle cx="14.5" cy="12" r="1.25" fill="#0B0B0B"></circle>
+            </svg>
+          </div>
           <h4>Lack of access</h4>
           <p>Warm investor intros are scarce; cold emails get lost.</p>
         </div>
         <div class="pi">
-          <div class="ic">🧩</div>
+          <div class="ic" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+              <rect x="4" y="5" width="4" height="14" rx="1" fill="#0B0B0B"></rect>
+              <rect x="10" y="8" width="4" height="8" rx="1" fill="#0B0B0B"></rect>
+              <path d="M18 6c1.657 0 3 1.343 3 3 0 2.25-3 2.25-3 4.5s3 2.25 3 4.5c0 1.657-1.343 3-3 3s-3-1.343-3-3" fill="none" stroke="#0B0B0B" stroke-width="2" stroke-linecap="round"></path>
+              <circle cx="18" cy="6" r="2" fill="#0B0B0B"></circle>
+            </svg>
+          </div>
           <h4>Signal vs. noise</h4>
           <p>Founders waste weeks on misaligned conversations.</p>
         </div>
         <div class="pi">
-          <div class="ic">💸</div>
+          <div class="ic" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+              <path d="M12 3l8 4v5c0 5.25-3.6 8.55-8 9-4.4-.45-8-3.75-8-9V7l8-4z" fill="#0B0B0B"></path>
+              <path d="M9.5 12.5l2 2 3.5-3.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </div>
           <h4>Compliance worries</h4>
           <p>Up‑front CAPEX and hidden OPEX deter investment.</p>
         </div>
         <div class="pi">
-          <div class="ic">📉</div>
+          <div class="ic" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+              <circle cx="12" cy="12" r="8" fill="#0B0B0B"></circle>
+              <circle cx="12" cy="12" r="6" fill="#FFFFFF"></circle>
+              <rect x="11.25" y="7" width="1.5" height="6" rx="0.75" fill="#0B0B0B"></rect>
+              <rect x="12" y="12" width="4" height="1.5" rx="0.75" fill="#0B0B0B" transform="rotate(45 12 12)"></rect>
+            </svg>
+          </div>
           <h4>Time cost</h4>
           <p>DIY outreach steals focus from product and customers.</p>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -126,7 +126,8 @@ h2{font-size:clamp(1.4rem, 1.3vw + 1.2rem, 2.1rem); margin:0 0 .85rem;font-weigh
 .problems{display:grid;grid-template-columns:repeat(4,1fr); gap:1rem}
 .pi{display:grid;gap:.4rem;background:linear-gradient(135deg,rgba(255,255,255,.75),rgba(255,255,255,.5));padding:1rem;border-radius:18px;border:1px solid rgba(255,255,255,.4);backdrop-filter:blur(18px);box-shadow:0 18px 30px rgba(15,23,42,.12);transition:transform .35s ease}
 .pi:hover{transform:translateY(-4px)}
-.pi .ic{width:38px;height:38px;border-radius:12px;background:rgba(10,132,255,.12);display:grid;place-items:center;border:1px solid rgba(10,132,255,.18)}
+.pi .ic{width:38px;height:38px;border-radius:12px;background:rgba(15,15,15,.06);display:grid;place-items:center;border:1px solid rgba(15,15,15,.1)}
+.pi .ic svg{width:22px;height:22px}
 .pi h4{margin:.2rem 0 .2rem;font-size:1rem}
 .pi p{margin:0;color:var(--muted);font-size:.95rem}
 


### PR DESCRIPTION
## Summary
- replace emoji placeholders in the "Fundraising Is Harder Than It Should Be" cards with custom black SVG icons
- adjust the icon container styling to better frame the new vector artwork

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d9dee846dc832595c7f098749881d2