### PR TITLE
Replace about section feature icons with vector art

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,42 +205,85 @@
 
       <div class="about-grid">
         <article class="about-feature">
-          <span class="feature-icon">💸</span>
+          <span class="feature-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <rect x="4.75" y="7.5" width="14.5" height="9.5" rx="2.2" fill="none" stroke="#0A84FF" stroke-width="1.8" />
+              <path d="M7.5 7.5v-1A2.5 2.5 0 0 1 10 4h4a2.5 2.5 0 0 1 2.5 2.5v1" fill="none" stroke="#0A84FF" stroke-width="1.8" />
+              <circle cx="16.4" cy="12.25" r="1.45" fill="none" stroke="#0A84FF" stroke-width="1.6" />
+              <path d="M8.3 12.6l2 2 3.7-3.7" fill="none" stroke="#0A84FF" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+          </span>
           <div>
             <h3>No Upfront Fees</h3>
             <p class="caption">Pay us only when a qualifying investor we introduced actually funds your round.</p>
           </div>
         </article>
         <article class="about-feature">
-          <span class="feature-icon">🤝</span>
+          <span class="feature-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <path d="M3.5 9.5c1.2-1.6 3.4-1.9 4.9-.6l3.1 2.7a1.6 1.6 0 0 0 2.1 0l1.9-1.6c1.5-1.3 3.7-1 4.9.6" fill="none" stroke="#0A84FF" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
+              <path d="M6.4 12.8l3.1 3a1.9 1.9 0 0 0 2.6 0l.9-.9a1.8 1.8 0 0 1 2.6 0l1 1" fill="none" stroke="#0A84FF" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
+              <path d="M4.5 15.2l1.7 1.7" fill="none" stroke="#0A84FF" stroke-width="1.8" stroke-linecap="round" />
+              <path d="M18 15.2l1.7 1.7" fill="none" stroke="#0A84FF" stroke-width="1.8" stroke-linecap="round" />
+            </svg>
+          </span>
           <div>
             <h3>Curated Intros</h3>
             <p class="caption">Warm introductions filtered by sector fit, cheque size, and investor thesis.</p>
           </div>
         </article>
         <article class="about-feature">
-          <span class="feature-icon">🔒</span>
+          <span class="feature-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <path d="M12 4.2l7 3.1v4.8c0 4.8-3 8.7-7 9.7-4-1-7-4.9-7-9.7V7.3l7-3.1z" fill="none" stroke="#0A84FF" stroke-width="1.8" stroke-linejoin="round" />
+              <rect x="9.2" y="11" width="5.6" height="4.9" rx="2.4" fill="none" stroke="#0A84FF" stroke-width="1.6" />
+              <path d="M12 11V9.2a2.8 2.8 0 0 1 5.6 0" fill="none" stroke="#0A84FF" stroke-width="1.6" stroke-linecap="round" />
+            </svg>
+          </span>
           <div>
             <h3>Privacy &amp; PDPA</h3>
             <p class="caption">Consent-based data sharing with retention controls and a clear deletion path.</p>
           </div>
         </article>
         <article class="about-feature">
-          <span class="feature-icon">📜</span>
+          <span class="feature-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <path d="M8 4h8.2a2.3 2.3 0 0 1 2.3 2.3V20H9.8A2.8 2.8 0 0 1 7 17.2V6.2A2.2 2.2 0 0 1 9.2 4" fill="none" stroke="#0A84FF" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
+              <path d="M8 8.2h9.5" fill="none" stroke="#0A84FF" stroke-width="1.6" stroke-linecap="round" />
+              <path d="M8 12h9.5" fill="none" stroke="#0A84FF" stroke-width="1.6" stroke-linecap="round" />
+              <path d="M11.2 20H19" fill="none" stroke="#0A84FF" stroke-width="1.6" stroke-linecap="round" />
+            </svg>
+          </span>
           <div>
             <h3>Transparent Terms</h3>
             <p class="caption">Explicit attribution windows and the ability to exclude existing investors.</p>
           </div>
         </article>
         <article class="about-feature">
-          <span class="feature-icon">⚡</span>
+          <span class="feature-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <circle cx="12" cy="12" r="7.5" fill="none" stroke="#0A84FF" stroke-width="1.8" />
+              <path d="M12 6.5v3.4l2.4 1.2" fill="none" stroke="#0A84FF" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
+              <path d="M8.3 16.2A5.8 5.8 0 0 1 5.2 12" fill="none" stroke="#0A84FF" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
+              <path d="M18.8 12a5.8 5.8 0 0 1-1.9 4.3" fill="none" stroke="#0A84FF" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
+              <path d="M15.8 5.4l2.4.6-.6 2.4" fill="none" stroke="#0A84FF" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+          </span>
           <div>
             <h3>Fast Turnaround</h3>
             <p class="caption">Most vetted introductions go out within <strong>7 days</strong> of completing intake.</p>
           </div>
         </article>
         <article class="about-feature">
-          <span class="feature-icon">⚖️</span>
+          <span class="feature-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <path d="M12 4v15.5" fill="none" stroke="#0A84FF" stroke-width="1.8" stroke-linecap="round" />
+              <path d="M6.5 7.4h11" fill="none" stroke="#0A84FF" stroke-width="1.8" stroke-linecap="round" />
+              <path d="M8.8 11.1l-2.3 4.5a2 2 0 0 0 1.8 2.9h2.5a2 2 0 0 0 1.8-2.9l-2.3-4.5z" fill="none" stroke="#0A84FF" stroke-width="1.6" stroke-linejoin="round" />
+              <path d="M15.2 11.1l-2.3 4.5a2 2 0 0 0 1.8 2.9h2.5a2 2 0 0 0 1.8-2.9l-2.3-4.5z" fill="none" stroke="#0A84FF" stroke-width="1.6" stroke-linejoin="round" />
+              <path d="M9.5 20h5" fill="none" stroke="#0A84FF" stroke-width="1.8" stroke-linecap="round" />
+            </svg>
+          </span>
           <div>
             <h3>Neutral &amp; Compliant</h3>
             <p class="caption">We simply facilitate intros—no advising, arranging, or handling of funds.</p>

--- a/styles.css
+++ b/styles.css
@@ -146,6 +146,7 @@ h2{font-size:clamp(1.4rem, 1.3vw + 1.2rem, 2.1rem); margin:0 0 .85rem;font-weigh
 .about-feature:hover{transform:translateY(-4px);box-shadow:0 34px 58px rgba(10,20,60,.18)}
 .about-feature h3{margin:0;font-size:1.05rem;letter-spacing:-.01em}
 .feature-icon{width:46px;height:46px;border-radius:16px;display:grid;place-items:center;font-size:1.3rem;background:linear-gradient(135deg,rgba(10,132,255,.22),rgba(90,200,250,.22));border:1px solid rgba(10,132,255,.28);box-shadow:0 12px 26px rgba(10,132,255,.18)}
+.feature-icon svg{width:26px;height:26px;display:block}
 .about-side{position:sticky;top:6.5rem;display:grid;gap:1rem;padding:2rem}
 .about-side h3{margin:0;font-size:1.35rem}
 .about-side .caption{color:rgba(15,23,42,.75)}


### PR DESCRIPTION
## Summary
- replace emoji placeholders in the about feature cards with inline one-color SVG icons
- keep icon styling consistent by sizing the new SVGs within the existing gradient icon container

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9e0e8bc508325b2b35bd5b088c5dd