### PR TITLE
Shrink WhatsApp widget on scroll and refresh icon

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -134,9 +134,16 @@ select.input{appearance:none;background:rgba(255,255,255,.82);background-image:l
   </div>
   <button class="whatsapp-toggle" type="button" aria-expanded="false" aria-controls="whatsapp-panel">
     <span class="toggle-icon" aria-hidden="true">
-      <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M12 2C6.48 2 2 6.06 2 11.06c0 2.86 1.34 5.42 3.44 7.2L4 22l4.03-1.34c1.21.33 2.49.5 3.97.5 5.52 0 10-4.06 10-9.06S17.52 2 12 2z" fill="#25D366"/>
-        <path d="M17.24 14.19c-.29.82-1.41 1.51-2.29 1.7-.61.13-1.39.23-4.05-.87-3.4-1.38-5.59-4.77-5.76-4.99-.17-.22-1.37-1.81-1.37-3.45 0-1.64.87-2.45 1.18-2.79.31-.34.68-.43.9-.43.22 0 .45.01.64.01.21 0 .49-.08.77.59.29.7.99 2.42 1.08 2.6.09.18.15.4.03.62-.12.22-.18.36-.36.55-.17.18-.36.4-.52.54-.17.14-.35.3-.15.59.2.29.9 1.48 1.94 2.39 1.34 1.19 2.46 1.57 2.76 1.75.29.18.46.15.63-.09.17-.23.73-.85.93-1.14.2-.29.4-.24.67-.14.27.09 1.71.81 2 .96.29.15.48.22.55.34.07.13.07.75-.22 1.57z" fill="#fff"/>
+      <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" role="img" aria-hidden="true">
+        <defs>
+          <linearGradient id="waGradientToggle" x1="8" y1="8" x2="40" y2="40" gradientUnits="userSpaceOnUse">
+            <stop offset="0" stop-color="#25D366"/>
+            <stop offset="1" stop-color="#128C7E"/>
+          </linearGradient>
+        </defs>
+        <circle cx="24" cy="24" r="22" fill="url(#waGradientToggle)"/>
+        <path d="M24 12c-6.63 0-12 4.94-12 11.03 0 2.62 1.05 5.08 2.89 6.99l-1.2 4.39 4.52-1.18c1.56.43 2.95.6 5.79.6 6.63 0 12-4.94 12-11.03C36 16.94 30.63 12 24 12z" fill="#fff" fill-opacity=".98"/>
+        <path d="M19.46 18.24c-.28-.62-.57-.63-.84-.63-.22 0-.45 0-.66 0-.23 0-.6.09-.91.43-.31.34-1.2 1.17-1.2 2.85 0 1.68 1.23 3.3 1.4 3.52.17.22 2.37 3.65 5.87 5.07 2.9 1.2 3.49.96 4.13.9.63-.06 2.03-.82 2.32-1.64.29-.82.29-1.53.2-1.68-.09-.15-.34-.24-.72-.42-.38-.18-2.27-1.11-2.62-1.23-.35-.12-.61-.18-.87.18-.26.36-1 1.23-1.23 1.49-.23.26-.45.28-.83.09-.38-.18-1.61-.59-3.07-1.88-1.14-1.01-1.91-2.26-2.14-2.63-.22-.36-.02-.55.17-.73.17-.17.38-.45.57-.68.18-.23.24-.39.36-.65.12-.26.06-.48-.03-.66-.09-.18-.82-2.01-1.13-2.73z" fill="url(#waGradientToggle)"/>
       </svg>
     </span>
     <span class="toggle-copy">
@@ -169,6 +176,11 @@ document.getElementById('next')?.addEventListener('click', function(e){
     cta.setAttribute('href', waLink);
   }
 
+  const updateScrollState = () => {
+    const shouldMinimize = window.scrollY > 40 && toggle.getAttribute('aria-expanded') === 'false';
+    widget.classList.toggle('is-scrolled', shouldMinimize);
+  };
+
   const openPanel = () => {
     if(panel.hasAttribute('data-closing')){
       panel.removeAttribute('data-closing');
@@ -178,6 +190,7 @@ document.getElementById('next')?.addEventListener('click', function(e){
     requestAnimationFrame(() => {
       widget.classList.add('is-open');
       toggle.setAttribute('aria-expanded', 'true');
+      updateScrollState();
     });
   };
 
@@ -186,6 +199,7 @@ document.getElementById('next')?.addEventListener('click', function(e){
     toggle.setAttribute('aria-expanded', 'false');
     panel.setAttribute('aria-hidden', 'true');
     panel.setAttribute('data-closing', 'true');
+    updateScrollState();
     setTimeout(() => {
       if(panel.getAttribute('data-closing') === 'true'){
         panel.hidden = true;
@@ -222,6 +236,9 @@ document.getElementById('next')?.addEventListener('click', function(e){
       closePanel();
     }
   });
+
+  window.addEventListener('scroll', updateScrollState, {passive: true});
+  updateScrollState();
 })();
 </script>
 

--- a/index.html
+++ b/index.html
@@ -344,9 +344,16 @@
   </div>
   <button class="whatsapp-toggle" type="button" aria-expanded="false" aria-controls="whatsapp-panel">
     <span class="toggle-icon" aria-hidden="true">
-      <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M12 2C6.48 2 2 6.06 2 11.06c0 2.86 1.34 5.42 3.44 7.2L4 22l4.03-1.34c1.21.33 2.49.5 3.97.5 5.52 0 10-4.06 10-9.06S17.52 2 12 2z" fill="#25D366"/>
-        <path d="M17.24 14.19c-.29.82-1.41 1.51-2.29 1.7-.61.13-1.39.23-4.05-.87-3.4-1.38-5.59-4.77-5.76-4.99-.17-.22-1.37-1.81-1.37-3.45 0-1.64.87-2.45 1.18-2.79.31-.34.68-.43.9-.43.22 0 .45.01.64.01.21 0 .49-.08.77.59.29.7.99 2.42 1.08 2.6.09.18.15.4.03.62-.12.22-.18.36-.36.55-.17.18-.36.4-.52.54-.17.14-.35.3-.15.59.2.29.9 1.48 1.94 2.39 1.34 1.19 2.46 1.57 2.76 1.75.29.18.46.15.63-.09.17-.23.73-.85.93-1.14.2-.29.4-.24.67-.14.27.09 1.71.81 2 .96.29.15.48.22.55.34.07.13.07.75-.22 1.57z" fill="#fff"/>
+      <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" role="img" aria-hidden="true">
+        <defs>
+          <linearGradient id="waGradientToggle" x1="8" y1="8" x2="40" y2="40" gradientUnits="userSpaceOnUse">
+            <stop offset="0" stop-color="#25D366"/>
+            <stop offset="1" stop-color="#128C7E"/>
+          </linearGradient>
+        </defs>
+        <circle cx="24" cy="24" r="22" fill="url(#waGradientToggle)"/>
+        <path d="M24 12c-6.63 0-12 4.94-12 11.03 0 2.62 1.05 5.08 2.89 6.99l-1.2 4.39 4.52-1.18c1.56.43 2.95.6 5.79.6 6.63 0 12-4.94 12-11.03C36 16.94 30.63 12 24 12z" fill="#fff" fill-opacity=".98"/>
+        <path d="M19.46 18.24c-.28-.62-.57-.63-.84-.63-.22 0-.45 0-.66 0-.23 0-.6.09-.91.43-.31.34-1.2 1.17-1.2 2.85 0 1.68 1.23 3.3 1.4 3.52.17.22 2.37 3.65 5.87 5.07 2.9 1.2 3.49.96 4.13.9.63-.06 2.03-.82 2.32-1.64.29-.82.29-1.53.2-1.68-.09-.15-.34-.24-.72-.42-.38-.18-2.27-1.11-2.62-1.23-.35-.12-.61-.18-.87.18-.26.36-1 1.23-1.23 1.49-.23.26-.45.28-.83.09-.38-.18-1.61-.59-3.07-1.88-1.14-1.01-1.91-2.26-2.14-2.63-.22-.36-.02-.55.17-.73.17-.17.38-.45.57-.68.18-.23.24-.39.36-.65.12-.26.06-.48-.03-.66-.09-.18-.82-2.01-1.13-2.73z" fill="url(#waGradientToggle)"/>
       </svg>
     </span>
     <span class="toggle-copy">
@@ -370,6 +377,11 @@
     cta.setAttribute('href', waLink);
   }
 
+  const updateScrollState = () => {
+    const shouldMinimize = window.scrollY > 40 && toggle.getAttribute('aria-expanded') === 'false';
+    widget.classList.toggle('is-scrolled', shouldMinimize);
+  };
+
   const openPanel = () => {
     if(panel.hasAttribute('data-closing')){
       panel.removeAttribute('data-closing');
@@ -379,6 +391,7 @@
     requestAnimationFrame(() => {
       widget.classList.add('is-open');
       toggle.setAttribute('aria-expanded', 'true');
+      updateScrollState();
     });
   };
 
@@ -387,6 +400,7 @@
     toggle.setAttribute('aria-expanded', 'false');
     panel.setAttribute('aria-hidden', 'true');
     panel.setAttribute('data-closing', 'true');
+    updateScrollState();
     setTimeout(() => {
       if(panel.getAttribute('data-closing') === 'true'){
         panel.hidden = true;
@@ -423,6 +437,9 @@
       closePanel();
     }
   });
+
+  window.addEventListener('scroll', updateScrollState, {passive: true});
+  updateScrollState();
 })();
 </script>
 

--- a/styles.css
+++ b/styles.css
@@ -181,14 +181,14 @@ hr.sep{border:0;border-top:1px solid #e6eaee;margin:1.75rem 0}
 
 /* whatsapp widget */
 .whatsapp-widget{position:fixed;right:26px;bottom:26px;z-index:120;display:flex;flex-direction:column;align-items:flex-end;gap:.9rem;font-family:"SF Pro Text","SF Pro Display",-apple-system,BlinkMacSystemFont,"Helvetica Neue",Helvetica,Arial,sans-serif}
-.whatsapp-widget .whatsapp-toggle{border:0;border-radius:999px;padding:.75rem 1.15rem;background:linear-gradient(135deg,#25D366,#128C7E);color:#fff;display:flex;align-items:center;gap:.7rem;font-weight:650;letter-spacing:-.01em;box-shadow:0 20px 44px rgba(18,140,126,.28),0 0 0 1px rgba(255,255,255,.3) inset;cursor:pointer;transition:transform .35s ease, box-shadow .35s ease}
+.whatsapp-widget .whatsapp-toggle{border:0;border-radius:999px;padding:.75rem 1.15rem;background:linear-gradient(135deg,#25D366,#128C7E);color:#fff;display:flex;align-items:center;gap:.7rem;font-weight:650;letter-spacing:-.01em;box-shadow:0 20px 44px rgba(18,140,126,.28),0 0 0 1px rgba(255,255,255,.3) inset;cursor:pointer;transition:transform .35s ease, box-shadow .35s ease, padding .3s ease, width .3s ease, height .3s ease, border-radius .3s ease, gap .3s ease}
 .whatsapp-widget .whatsapp-toggle:focus-visible{outline:3px solid rgba(37,211,102,.55);outline-offset:3px}
 .whatsapp-widget .whatsapp-toggle:hover{transform:translateY(-2px) scale(1.02);box-shadow:0 28px 58px rgba(18,140,126,.36)}
-.whatsapp-widget .toggle-icon{width:38px;height:38px;border-radius:50%;display:grid;place-items:center;background:rgba(255,255,255,.22);box-shadow:0 12px 20px rgba(10,20,30,.25) inset,0 4px 10px rgba(0,0,0,.18)}
+.whatsapp-widget .toggle-icon{width:38px;height:38px;border-radius:50%;display:grid;place-items:center;background:rgba(255,255,255,.22);box-shadow:0 12px 20px rgba(10,20,30,.25) inset,0 4px 10px rgba(0,0,0,.18);transition:width .3s ease, height .3s ease, box-shadow .3s ease, background .3s ease}
 .whatsapp-widget .toggle-icon svg{width:22px;height:22px;display:block}
 .whatsapp-widget .toggle-copy{display:grid;gap:.1rem;text-align:left}
-.whatsapp-widget .toggle-copy strong{font-size:.98rem;line-height:1;font-weight:650}
-.whatsapp-widget .toggle-copy span{font-size:.78rem;letter-spacing:.04em;text-transform:uppercase;color:rgba(255,255,255,.76);font-weight:600}
+.whatsapp-widget .toggle-copy strong{font-size:.98rem;line-height:1;font-weight:650;transition:opacity .25s ease}
+.whatsapp-widget .toggle-copy span{font-size:.78rem;letter-spacing:.04em;text-transform:uppercase;color:rgba(255,255,255,.76);font-weight:600;transition:opacity .25s ease}
 .whatsapp-panel{width:min(320px,calc(100vw - 2.4rem));border-radius:22px;background:linear-gradient(150deg,rgba(18,140,126,.96),rgba(37,211,102,.88));color:#f4fff8;box-shadow:0 32px 60px rgba(18,140,126,.35);border:1px solid rgba(255,255,255,.35);overflow:hidden;transform-origin:bottom right;opacity:0;transform:translateY(12px) scale(.96);pointer-events:none;transition:opacity .28s ease, transform .32s cubic-bezier(.2,.8,.2,1)}
 .whatsapp-widget.is-open .whatsapp-panel{opacity:1;transform:translateY(0) scale(1);pointer-events:auto}
 .whatsapp-panel__header{display:flex;align-items:flex-start;gap:.8rem;padding:1rem 1.1rem 0 1.1rem}
@@ -206,6 +206,9 @@ hr.sep{border:0;border-top:1px solid #e6eaee;margin:1.75rem 0}
 .whatsapp-panel__cta:focus-visible{outline:3px solid rgba(255,255,255,.65);outline-offset:3px}
 .whatsapp-panel__note{font-size:.75rem;color:rgba(244,255,248,.78);line-height:1.4}
 .whatsapp-panel__note a{color:#fff;font-weight:600}
+.whatsapp-widget.is-scrolled:not(.is-open) .whatsapp-toggle{padding:0;width:3.25rem;height:3.25rem;gap:0;border-radius:50%;justify-content:center;box-shadow:0 18px 36px rgba(18,140,126,.32)}
+.whatsapp-widget.is-scrolled:not(.is-open) .toggle-icon{width:2.4rem;height:2.4rem;background:rgba(255,255,255,.18);box-shadow:0 6px 14px rgba(0,0,0,.16)}
+.whatsapp-widget.is-scrolled:not(.is-open) .toggle-copy{display:none}
 
 /* responsive */
 @media (max-width: 1040px){


### PR DESCRIPTION
## Summary
- shrink the floating WhatsApp button into a compact circular badge while the page is scrolled
- swap in the refreshed WhatsApp SVG artwork to match the current brand
- ensure the widget expands again when opened and keeps accessibility attributes intact

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d9e58962048325b958047752033b52