### PR TITLE
Taper WhatsApp widget animation to scrolling

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -116,6 +116,36 @@ select.input{appearance:none;background:rgba(255,255,255,.82);background-image:l
   </div>
 </footer>
 
+<div class="whatsapp-widget" data-wa-link="https://wa.me/94723652618">
+  <div class="whatsapp-panel" id="whatsapp-panel" hidden aria-hidden="true">
+    <div class="whatsapp-panel__header">
+      <div class="whatsapp-panel__avatar" aria-hidden="true">💬</div>
+      <div class="whatsapp-panel__title">
+        <strong>Capital Connect LK</strong>
+        <span class="whatsapp-panel__status">We're online</span>
+      </div>
+      <button class="whatsapp-close" type="button" aria-label="Close WhatsApp chat">✕</button>
+    </div>
+    <div class="whatsapp-panel__body">
+      <div class="whatsapp-panel__message">Questions about the intake form or investor introductions? Tap below to open a WhatsApp chat and we’ll assist you shortly.</div>
+      <a class="whatsapp-panel__cta" href="https://wa.me/94723652618" target="_blank" rel="noopener">Open WhatsApp</a>
+      <p class="whatsapp-panel__note">You’ll be taken to WhatsApp in a new tab. Email works too: <a href="mailto:hello@capitalconnectlk.info">hello@capitalconnectlk.info</a>.</p>
+    </div>
+  </div>
+  <button class="whatsapp-toggle" type="button" aria-expanded="false" aria-controls="whatsapp-panel">
+    <span class="toggle-icon" aria-hidden="true">
+      <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M12 2C6.48 2 2 6.06 2 11.06c0 2.86 1.34 5.42 3.44 7.2L4 22l4.03-1.34c1.21.33 2.49.5 3.97.5 5.52 0 10-4.06 10-9.06S17.52 2 12 2z" fill="#25D366"/>
+        <path d="M17.24 14.19c-.29.82-1.41 1.51-2.29 1.7-.61.13-1.39.23-4.05-.87-3.4-1.38-5.59-4.77-5.76-4.99-.17-.22-1.37-1.81-1.37-3.45 0-1.64.87-2.45 1.18-2.79.31-.34.68-.43.9-.43.22 0 .45.01.64.01.21 0 .49-.08.77.59.29.7.99 2.42 1.08 2.6.09.18.15.4.03.62-.12.22-.18.36-.36.55-.17.18-.36.4-.52.54-.17.14-.35.3-.15.59.2.29.9 1.48 1.94 2.39 1.34 1.19 2.46 1.57 2.76 1.75.29.18.46.15.63-.09.17-.23.73-.85.93-1.14.2-.29.4-.24.67-.14.27.09 1.71.81 2 .96.29.15.48.22.55.34.07.13.07.75-.22 1.57z" fill="#fff"/>
+      </svg>
+    </span>
+    <span class="toggle-copy">
+      <strong>Chat with us</strong>
+      <span>WhatsApp</span>
+    </span>
+  </button>
+</div>
+
 <script>
 // simple progress demo
 document.getElementById('next')?.addEventListener('click', function(e){
@@ -123,6 +153,172 @@ document.getElementById('next')?.addEventListener('click', function(e){
   const bar = document.querySelector('.progress > i');
   bar.style.width = '66%';
 });
+</script>
+
+<script>
+(function(){
+  const widget = document.querySelector('.whatsapp-widget');
+  if(!widget) return;
+  const toggle = widget.querySelector('.whatsapp-toggle');
+  const panel = widget.querySelector('.whatsapp-panel');
+  const closeBtn = widget.querySelector('.whatsapp-close');
+  const cta = widget.querySelector('.whatsapp-panel__cta');
+  const waLink = widget.getAttribute('data-wa-link');
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  if(waLink && cta){
+    cta.setAttribute('href', waLink);
+  }
+
+  let closeTimer;
+
+  const finishClosing = () => {
+    if(closeTimer){
+      clearTimeout(closeTimer);
+      closeTimer = undefined;
+    }
+    if(panel.getAttribute('data-closing') === 'true'){
+      panel.hidden = true;
+      panel.removeAttribute('data-closing');
+    }
+  };
+
+  panel.addEventListener('transitionend', (event) => {
+    if(event.target === panel && event.propertyName === 'opacity'){
+      finishClosing();
+    }
+  });
+
+  panel.addEventListener('transitioncancel', (event) => {
+    if(event.target === panel){
+      finishClosing();
+    }
+  });
+
+  const openPanel = () => {
+    if(closeTimer){
+      clearTimeout(closeTimer);
+      closeTimer = undefined;
+    }
+    panel.hidden = false;
+    panel.removeAttribute('data-closing');
+    panel.setAttribute('aria-hidden', 'false');
+    requestAnimationFrame(() => {
+      widget.classList.add('is-open');
+      toggle.setAttribute('aria-expanded', 'true');
+    });
+  };
+
+  const closePanel = () => {
+    if(panel.hidden || panel.getAttribute('data-closing') === 'true'){
+      return;
+    }
+    panel.setAttribute('data-closing', 'true');
+    widget.classList.remove('is-open');
+    toggle.setAttribute('aria-expanded', 'false');
+    panel.setAttribute('aria-hidden', 'true');
+
+    if(prefersReducedMotion.matches){
+      finishClosing();
+      return;
+    }
+
+    const duration = parseFloat(getComputedStyle(widget).getPropertyValue('--wa-motion-duration')) || .6;
+    closeTimer = window.setTimeout(finishClosing, duration * 1000 + 80);
+  };
+
+  toggle.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    if(expanded){
+      closePanel();
+    } else {
+      openPanel();
+    }
+  });
+
+  closeBtn.addEventListener('click', closePanel);
+
+  if(cta){
+    cta.addEventListener('click', () => {
+      closePanel();
+    });
+  }
+
+  document.addEventListener('click', (event) => {
+    if(!widget.contains(event.target) && toggle.getAttribute('aria-expanded') === 'true'){
+      closePanel();
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if(event.key === 'Escape' && toggle.getAttribute('aria-expanded') === 'true'){
+      closePanel();
+    }
+  });
+
+  let lastScrollY = window.scrollY;
+  let lastTimestamp = performance.now();
+  let smoothedVelocity = 0;
+  let scrollRaf;
+  let resetShift;
+
+  const handleScroll = () => {
+    if(prefersReducedMotion.matches){
+      widget.style.setProperty('--wa-scroll-shift', '0px');
+      lastScrollY = window.scrollY;
+      lastTimestamp = performance.now();
+      return;
+    }
+
+    if(scrollRaf){
+      cancelAnimationFrame(scrollRaf);
+    }
+    scrollRaf = requestAnimationFrame(() => {
+      const now = performance.now();
+      const currentY = window.scrollY;
+      const deltaY = currentY - lastScrollY;
+      const elapsed = Math.max(now - lastTimestamp, 16);
+      const velocity = Math.min(Math.abs(deltaY) / elapsed, 2.2);
+      smoothedVelocity = smoothedVelocity * 0.8 + velocity * 0.2;
+
+      const normalized = Math.min(smoothedVelocity / 1.4, 1);
+      const duration = 0.65 - normalized * 0.2;
+      widget.style.setProperty('--wa-motion-duration', `${duration.toFixed(3)}s`);
+
+      const direction = deltaY === 0 ? 0 : deltaY > 0 ? 1 : -1;
+      const shift = direction * Math.min(Math.abs(deltaY) * 0.35, 18);
+      widget.style.setProperty('--wa-scroll-shift', `${shift.toFixed(2)}px`);
+
+      if(resetShift){
+        clearTimeout(resetShift);
+      }
+      resetShift = window.setTimeout(() => {
+        widget.style.setProperty('--wa-scroll-shift', '0px');
+      }, 160);
+
+      lastScrollY = currentY;
+      lastTimestamp = now;
+    });
+  };
+
+  window.addEventListener('scroll', handleScroll, {passive: true});
+
+  const syncReducedMotion = () => {
+    if(prefersReducedMotion.matches){
+      widget.style.setProperty('--wa-motion-duration', '.01s');
+      widget.style.setProperty('--wa-scroll-shift', '0px');
+    } else {
+      widget.style.setProperty('--wa-motion-duration', '.6s');
+    }
+  };
+
+  if(typeof prefersReducedMotion.addEventListener === 'function'){
+    prefersReducedMotion.addEventListener('change', syncReducedMotion);
+  } else if(typeof prefersReducedMotion.addListener === 'function'){
+    prefersReducedMotion.addListener(syncReducedMotion);
+  }
+  syncReducedMotion();
+})();
 </script>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -326,5 +326,201 @@
   </div>
 </footer>
 
+<div class="whatsapp-widget" data-wa-link="https://wa.me/94723652618">
+  <div class="whatsapp-panel" id="whatsapp-panel" hidden aria-hidden="true">
+    <div class="whatsapp-panel__header">
+      <div class="whatsapp-panel__avatar" aria-hidden="true">💬</div>
+      <div class="whatsapp-panel__title">
+        <strong>Capital Connect LK</strong>
+        <span class="whatsapp-panel__status">We're online</span>
+      </div>
+      <button class="whatsapp-close" type="button" aria-label="Close WhatsApp chat">✕</button>
+    </div>
+    <div class="whatsapp-panel__body">
+      <div class="whatsapp-panel__message">Hi there! Need curated investor introductions or have a question about our intake? Start a WhatsApp chat and we’ll get back fast.</div>
+      <a class="whatsapp-panel__cta" href="https://wa.me/94723652618" target="_blank" rel="noopener">Open WhatsApp</a>
+      <p class="whatsapp-panel__note">WhatsApp opens in a new tab. Prefer email? Reach us at <a href="mailto:hello@capitalconnectlk.info">hello@capitalconnectlk.info</a>.</p>
+    </div>
+  </div>
+  <button class="whatsapp-toggle" type="button" aria-expanded="false" aria-controls="whatsapp-panel">
+    <span class="toggle-icon" aria-hidden="true">
+      <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M12 2C6.48 2 2 6.06 2 11.06c0 2.86 1.34 5.42 3.44 7.2L4 22l4.03-1.34c1.21.33 2.49.5 3.97.5 5.52 0 10-4.06 10-9.06S17.52 2 12 2z" fill="#25D366"/>
+        <path d="M17.24 14.19c-.29.82-1.41 1.51-2.29 1.7-.61.13-1.39.23-4.05-.87-3.4-1.38-5.59-4.77-5.76-4.99-.17-.22-1.37-1.81-1.37-3.45 0-1.64.87-2.45 1.18-2.79.31-.34.68-.43.9-.43.22 0 .45.01.64.01.21 0 .49-.08.77.59.29.7.99 2.42 1.08 2.6.09.18.15.4.03.62-.12.22-.18.36-.36.55-.17.18-.36.4-.52.54-.17.14-.35.3-.15.59.2.29.9 1.48 1.94 2.39 1.34 1.19 2.46 1.57 2.76 1.75.29.18.46.15.63-.09.17-.23.73-.85.93-1.14.2-.29.4-.24.67-.14.27.09 1.71.81 2 .96.29.15.48.22.55.34.07.13.07.75-.22 1.57z" fill="#fff"/>
+      </svg>
+    </span>
+    <span class="toggle-copy">
+      <strong>Chat with us</strong>
+      <span>WhatsApp</span>
+    </span>
+  </button>
+</div>
+
+<script>
+(function(){
+  const widget = document.querySelector('.whatsapp-widget');
+  if(!widget) return;
+  const toggle = widget.querySelector('.whatsapp-toggle');
+  const panel = widget.querySelector('.whatsapp-panel');
+  const closeBtn = widget.querySelector('.whatsapp-close');
+  const cta = widget.querySelector('.whatsapp-panel__cta');
+  const waLink = widget.getAttribute('data-wa-link');
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  if(waLink && cta){
+    cta.setAttribute('href', waLink);
+  }
+
+  let closeTimer;
+
+  const finishClosing = () => {
+    if(closeTimer){
+      clearTimeout(closeTimer);
+      closeTimer = undefined;
+    }
+    if(panel.getAttribute('data-closing') === 'true'){
+      panel.hidden = true;
+      panel.removeAttribute('data-closing');
+    }
+  };
+
+  panel.addEventListener('transitionend', (event) => {
+    if(event.target === panel && event.propertyName === 'opacity'){
+      finishClosing();
+    }
+  });
+
+  panel.addEventListener('transitioncancel', (event) => {
+    if(event.target === panel){
+      finishClosing();
+    }
+  });
+
+  const openPanel = () => {
+    if(closeTimer){
+      clearTimeout(closeTimer);
+      closeTimer = undefined;
+    }
+    panel.hidden = false;
+    panel.removeAttribute('data-closing');
+    panel.setAttribute('aria-hidden', 'false');
+    requestAnimationFrame(() => {
+      widget.classList.add('is-open');
+      toggle.setAttribute('aria-expanded', 'true');
+    });
+  };
+
+  const closePanel = () => {
+    if(panel.hidden || panel.getAttribute('data-closing') === 'true'){
+      return;
+    }
+    panel.setAttribute('data-closing', 'true');
+    widget.classList.remove('is-open');
+    toggle.setAttribute('aria-expanded', 'false');
+    panel.setAttribute('aria-hidden', 'true');
+
+    if(prefersReducedMotion.matches){
+      finishClosing();
+      return;
+    }
+
+    const duration = parseFloat(getComputedStyle(widget).getPropertyValue('--wa-motion-duration')) || .6;
+    closeTimer = window.setTimeout(finishClosing, duration * 1000 + 80);
+  };
+
+  toggle.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    if(expanded){
+      closePanel();
+    } else {
+      openPanel();
+    }
+  });
+
+  closeBtn.addEventListener('click', closePanel);
+
+  if(cta){
+    cta.addEventListener('click', () => {
+      closePanel();
+    });
+  }
+
+  document.addEventListener('click', (event) => {
+    if(!widget.contains(event.target) && toggle.getAttribute('aria-expanded') === 'true'){
+      closePanel();
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if(event.key === 'Escape' && toggle.getAttribute('aria-expanded') === 'true'){
+      closePanel();
+    }
+  });
+
+  let lastScrollY = window.scrollY;
+  let lastTimestamp = performance.now();
+  let smoothedVelocity = 0;
+  let scrollRaf;
+  let resetShift;
+
+  const handleScroll = () => {
+    if(prefersReducedMotion.matches){
+      widget.style.setProperty('--wa-scroll-shift', '0px');
+      lastScrollY = window.scrollY;
+      lastTimestamp = performance.now();
+      return;
+    }
+
+    if(scrollRaf){
+      cancelAnimationFrame(scrollRaf);
+    }
+    scrollRaf = requestAnimationFrame(() => {
+      const now = performance.now();
+      const currentY = window.scrollY;
+      const deltaY = currentY - lastScrollY;
+      const elapsed = Math.max(now - lastTimestamp, 16);
+      const velocity = Math.min(Math.abs(deltaY) / elapsed, 2.2);
+      smoothedVelocity = smoothedVelocity * 0.8 + velocity * 0.2;
+
+      const normalized = Math.min(smoothedVelocity / 1.4, 1);
+      const duration = 0.65 - normalized * 0.2;
+      widget.style.setProperty('--wa-motion-duration', `${duration.toFixed(3)}s`);
+
+      const direction = deltaY === 0 ? 0 : deltaY > 0 ? 1 : -1;
+      const shift = direction * Math.min(Math.abs(deltaY) * 0.35, 18);
+      widget.style.setProperty('--wa-scroll-shift', `${shift.toFixed(2)}px`);
+
+      if(resetShift){
+        clearTimeout(resetShift);
+      }
+      resetShift = window.setTimeout(() => {
+        widget.style.setProperty('--wa-scroll-shift', '0px');
+      }, 160);
+
+      lastScrollY = currentY;
+      lastTimestamp = now;
+    });
+  };
+
+  window.addEventListener('scroll', handleScroll, {passive: true});
+
+  const syncReducedMotion = () => {
+    if(prefersReducedMotion.matches){
+      widget.style.setProperty('--wa-motion-duration', '.01s');
+      widget.style.setProperty('--wa-scroll-shift', '0px');
+    } else {
+      widget.style.setProperty('--wa-motion-duration', '.6s');
+    }
+  };
+
+  if(typeof prefersReducedMotion.addEventListener === 'function'){
+    prefersReducedMotion.addEventListener('change', syncReducedMotion);
+  } else if(typeof prefersReducedMotion.addListener === 'function'){
+    prefersReducedMotion.addListener(syncReducedMotion);
+  }
+  syncReducedMotion();
+})();
+</script>
+
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -179,6 +179,35 @@ h2{font-size:clamp(1.4rem, 1.3vw + 1.2rem, 2.1rem); margin:0 0 .85rem;font-weigh
 .caption{color:var(--muted);font-size:.95rem}
 hr.sep{border:0;border-top:1px solid #e6eaee;margin:1.75rem 0}
 
+/* whatsapp widget */
+.whatsapp-widget{position:fixed;right:26px;bottom:26px;z-index:120;display:flex;flex-direction:column;align-items:flex-end;gap:.9rem;font-family:"SF Pro Text","SF Pro Display",-apple-system,BlinkMacSystemFont,"Helvetica Neue",Helvetica,Arial,sans-serif;--wa-motion-duration:.6s;--wa-scroll-shift:0px;transition:transform var(--wa-motion-duration) cubic-bezier(.22,1,.36,1);transform:translate3d(0,var(--wa-scroll-shift),0)}
+.whatsapp-widget .whatsapp-toggle{border:0;border-radius:999px;padding:.75rem 1.15rem;background:linear-gradient(135deg,#25D366,#128C7E);color:#fff;display:flex;align-items:center;gap:.7rem;font-weight:650;letter-spacing:-.01em;box-shadow:0 20px 44px rgba(18,140,126,.28),0 0 0 1px rgba(255,255,255,.3) inset;cursor:pointer;transition:transform var(--wa-motion-duration) cubic-bezier(.22,1,.36,1), box-shadow var(--wa-motion-duration) ease}
+.whatsapp-widget .whatsapp-toggle:focus-visible{outline:3px solid rgba(37,211,102,.55);outline-offset:3px}
+.whatsapp-widget .whatsapp-toggle:hover{transform:translateY(-2px) scale(1.02);box-shadow:0 28px 58px rgba(18,140,126,.36)}
+.whatsapp-widget .toggle-icon{width:38px;height:38px;border-radius:50%;display:grid;place-items:center;background:rgba(255,255,255,.22);box-shadow:0 12px 20px rgba(10,20,30,.25) inset,0 4px 10px rgba(0,0,0,.18)}
+.whatsapp-widget .toggle-icon svg{width:22px;height:22px;display:block}
+.whatsapp-widget .toggle-copy{display:grid;gap:.1rem;text-align:left}
+.whatsapp-widget .toggle-copy strong{font-size:.98rem;line-height:1;font-weight:650}
+.whatsapp-widget .toggle-copy span{font-size:.78rem;letter-spacing:.04em;text-transform:uppercase;color:rgba(255,255,255,.76);font-weight:600}
+.whatsapp-panel{width:min(320px,calc(100vw - 2.4rem));border-radius:22px;background:linear-gradient(150deg,rgba(18,140,126,.96),rgba(37,211,102,.88));color:#f4fff8;box-shadow:0 32px 60px rgba(18,140,126,.35);border:1px solid rgba(255,255,255,.35);overflow:hidden;transform-origin:bottom right;opacity:0;transform:translate3d(0,calc(12px + var(--wa-scroll-shift)),0) scale(.94);pointer-events:none;transition:opacity var(--wa-motion-duration) cubic-bezier(.16,1,.3,1), transform var(--wa-motion-duration) cubic-bezier(.16,1,.3,1)}
+.whatsapp-widget.is-open .whatsapp-panel{opacity:1;transform:translate3d(0,var(--wa-scroll-shift),0) scale(1);pointer-events:auto}
+.whatsapp-panel[data-closing="true"]{pointer-events:none}
+.whatsapp-panel__header{display:flex;align-items:flex-start;gap:.8rem;padding:1rem 1.1rem 0 1.1rem}
+.whatsapp-panel__avatar{width:44px;height:44px;border-radius:14px;background:rgba(255,255,255,.2);display:grid;place-items:center;font-size:1.35rem;box-shadow:0 12px 20px rgba(10,20,30,.22)}
+.whatsapp-panel__title{display:grid;gap:.25rem}
+.whatsapp-panel__title strong{font-size:1rem;letter-spacing:-.01em}
+.whatsapp-panel__status{font-size:.78rem;text-transform:uppercase;letter-spacing:.08em;color:rgba(244,255,248,.78);font-weight:600}
+.whatsapp-close{margin-left:auto;background:rgba(0,0,0,.12);border:0;color:#fff;width:32px;height:32px;border-radius:50%;display:grid;place-items:center;cursor:pointer;transition:background .25s ease}
+.whatsapp-close:hover{background:rgba(0,0,0,.25)}
+.whatsapp-close:focus-visible{outline:3px solid rgba(244,255,248,.6);outline-offset:2px}
+.whatsapp-panel__body{padding:1rem 1.1rem 1.2rem 1.1rem;display:grid;gap:1rem}
+.whatsapp-panel__message{background:rgba(0,0,0,.1);padding:.85rem 1rem;border-radius:18px 18px 4px 18px;line-height:1.4;font-size:.92rem;box-shadow:0 14px 26px rgba(0,0,0,.16)}
+.whatsapp-panel__cta{display:inline-flex;align-items:center;justify-content:center;gap:.5rem;padding:.7rem 1.1rem;border-radius:999px;background:#fff;color:#128c7e;font-weight:650;text-transform:uppercase;font-size:.78rem;letter-spacing:.1em;box-shadow:0 16px 32px rgba(0,0,0,.18);transition:transform .3s ease, box-shadow .3s ease}
+.whatsapp-panel__cta:hover{transform:translateY(-2px);box-shadow:0 24px 40px rgba(0,0,0,.22)}
+.whatsapp-panel__cta:focus-visible{outline:3px solid rgba(255,255,255,.65);outline-offset:3px}
+.whatsapp-panel__note{font-size:.75rem;color:rgba(244,255,248,.78);line-height:1.4}
+.whatsapp-panel__note a{color:#fff;font-weight:600}
+
 /* responsive */
 @media (max-width: 1040px){
   .fees-grid{grid-template-columns:repeat(2,minmax(0,1fr));}
@@ -202,6 +231,17 @@ hr.sep{border:0;border-top:1px solid #e6eaee;margin:1.75rem 0}
   .header-inner{padding:.7rem .8rem}
   .hero{padding:3.6rem 0 2.2rem}
   .mac-screen{grid-template-columns:1fr}
+  .whatsapp-widget{right:14px;bottom:18px;width:calc(100% - 1.8rem)}
+  .whatsapp-panel{width:100%}
+}
+
+@media (prefers-reduced-motion: reduce){
+  .whatsapp-widget,
+  .whatsapp-widget .whatsapp-toggle,
+  .whatsapp-panel{
+    transition:none!important;
+    animation:none!important;
+  }
 }
 
 /* mac window illustration */


### PR DESCRIPTION
## Summary
- smooth the WhatsApp widget open/close motion with scroll-synced transitions
- add JavaScript that eases panel closing, respects reduced-motion settings, and tracks scroll velocity
- update styling to use shared motion variables and disable animations for accessibility

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_68d9e224de908325a24224f742e42be0