### PR TITLE
Make WhatsApp widget collapse track scroll speed

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -170,16 +170,165 @@ document.getElementById('next')?.addEventListener('click', function(e){
   const panel = widget.querySelector('.whatsapp-panel');
   const closeBtn = widget.querySelector('.whatsapp-close');
   const cta = widget.querySelector('.whatsapp-panel__cta');
+  const toggleIcon = toggle.querySelector('.toggle-icon');
+  const toggleCopy = toggle.querySelector('.toggle-copy');
   const waLink = widget.getAttribute('data-wa-link');
 
   if(waLink && cta){
     cta.setAttribute('href', waLink);
   }
 
-  const updateScrollState = () => {
-    const shouldMinimize = window.scrollY > 40 && toggle.getAttribute('aria-expanded') === 'false';
-    widget.classList.toggle('is-scrolled', shouldMinimize);
+  const collapseRange = 180;
+  const collapsedShadow = '0 18px 36px rgba(18,140,126,.32)';
+  const collapsedIconShadow = '0 6px 14px rgba(0,0,0,.16)';
+  const collapsedIconBg = 'rgba(255,255,255,.18)';
+  let rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+  let collapsedSize = 3.25 * rootFontSize;
+  let collapsedIconSize = 2.4 * rootFontSize;
+  let collapsedRadius = collapsedSize / 2;
+  let expandedWidth = 0;
+  let expandedHeight = 0;
+  let expandedPaddingY = 0;
+  let expandedPaddingX = 0;
+  let expandedGap = 0;
+  let expandedRadius = 999;
+  let expandedShadow = getComputedStyle(toggle).boxShadow;
+  let expandedJustify = getComputedStyle(toggle).justifyContent || 'flex-start';
+  let expandedIconSize = 0;
+  let expandedIconShadow = getComputedStyle(toggleIcon).boxShadow;
+  let expandedIconBg = getComputedStyle(toggleIcon).backgroundColor;
+  let collapseProgress = 0;
+  let pendingProgress = 0;
+  let frameId = null;
+
+  const captureExpandedMetrics = () => {
+    const stored = {
+      width: toggle.style.getPropertyValue('--wa-toggle-width'),
+      height: toggle.style.getPropertyValue('--wa-toggle-height'),
+      paddingY: toggle.style.getPropertyValue('--wa-toggle-padding-y'),
+      paddingX: toggle.style.getPropertyValue('--wa-toggle-padding-x'),
+      gap: toggle.style.getPropertyValue('--wa-toggle-gap'),
+      radius: toggle.style.getPropertyValue('--wa-toggle-radius'),
+      justify: toggle.style.getPropertyValue('--wa-toggle-justify'),
+      copyOpacity: toggle.style.getPropertyValue('--wa-toggle-copy-opacity'),
+      copyShift: toggle.style.getPropertyValue('--wa-toggle-copy-shift'),
+      copyVisibility: toggle.style.getPropertyValue('--wa-toggle-copy-visibility'),
+      boxShadow: toggle.style.boxShadow,
+      iconSize: toggleIcon.style.getPropertyValue('--wa-toggle-icon-size'),
+      iconShadow: toggleIcon.style.getPropertyValue('--wa-toggle-icon-shadow'),
+      iconBg: toggleIcon.style.getPropertyValue('--wa-toggle-icon-bg'),
+      pointerEvents: toggleCopy ? toggleCopy.style.pointerEvents : undefined
+    };
+
+    toggle.style.removeProperty('--wa-toggle-width');
+    toggle.style.removeProperty('--wa-toggle-height');
+    toggle.style.removeProperty('--wa-toggle-padding-y');
+    toggle.style.removeProperty('--wa-toggle-padding-x');
+    toggle.style.removeProperty('--wa-toggle-gap');
+    toggle.style.removeProperty('--wa-toggle-radius');
+    toggle.style.removeProperty('--wa-toggle-justify');
+    toggle.style.removeProperty('--wa-toggle-copy-opacity');
+    toggle.style.removeProperty('--wa-toggle-copy-shift');
+    toggle.style.removeProperty('--wa-toggle-copy-visibility');
+    toggle.style.boxShadow = '';
+    toggleIcon.style.removeProperty('--wa-toggle-icon-size');
+    toggleIcon.style.removeProperty('--wa-toggle-icon-shadow');
+    toggleIcon.style.removeProperty('--wa-toggle-icon-bg');
+    if(toggleCopy){
+      toggleCopy.style.pointerEvents = '';
+    }
+
+    const toggleStyles = getComputedStyle(toggle);
+    const iconStyles = getComputedStyle(toggleIcon);
+    expandedJustify = toggleStyles.justifyContent || 'flex-start';
+    expandedShadow = toggleStyles.boxShadow;
+    expandedGap = parseFloat(toggleStyles.columnGap || toggleStyles.gap) || 0;
+    expandedPaddingY = parseFloat(toggleStyles.paddingTop) || 0;
+    expandedPaddingX = parseFloat(toggleStyles.paddingLeft) || 0;
+    expandedRadius = parseFloat(toggleStyles.borderTopLeftRadius) || 999;
+    const rect = toggle.getBoundingClientRect();
+    expandedWidth = rect.width;
+    expandedHeight = rect.height;
+    const iconRect = toggleIcon.getBoundingClientRect();
+    expandedIconSize = iconRect.width;
+    expandedIconShadow = iconStyles.boxShadow;
+    expandedIconBg = iconStyles.backgroundColor;
+
+    if(stored.width) toggle.style.setProperty('--wa-toggle-width', stored.width);
+    if(stored.height) toggle.style.setProperty('--wa-toggle-height', stored.height);
+    if(stored.paddingY) toggle.style.setProperty('--wa-toggle-padding-y', stored.paddingY);
+    if(stored.paddingX) toggle.style.setProperty('--wa-toggle-padding-x', stored.paddingX);
+    if(stored.gap) toggle.style.setProperty('--wa-toggle-gap', stored.gap);
+    if(stored.radius) toggle.style.setProperty('--wa-toggle-radius', stored.radius);
+    if(stored.justify) toggle.style.setProperty('--wa-toggle-justify', stored.justify);
+    if(stored.copyOpacity) toggle.style.setProperty('--wa-toggle-copy-opacity', stored.copyOpacity);
+    if(stored.copyShift) toggle.style.setProperty('--wa-toggle-copy-shift', stored.copyShift);
+    if(stored.copyVisibility) toggle.style.setProperty('--wa-toggle-copy-visibility', stored.copyVisibility);
+    if(stored.boxShadow) toggle.style.boxShadow = stored.boxShadow;
+    if(stored.iconSize) toggleIcon.style.setProperty('--wa-toggle-icon-size', stored.iconSize);
+    if(stored.iconShadow) toggleIcon.style.setProperty('--wa-toggle-icon-shadow', stored.iconShadow);
+    if(stored.iconBg) toggleIcon.style.setProperty('--wa-toggle-icon-bg', stored.iconBg);
+    if(toggleCopy && stored.pointerEvents !== undefined){
+      toggleCopy.style.pointerEvents = stored.pointerEvents;
+    }
   };
+
+  const applyProgress = (progress) => {
+    collapseProgress = progress;
+    widget.style.setProperty('--wa-collapse-progress', progress.toFixed(3));
+    const inverse = 1 - progress;
+    const width = collapsedSize + (expandedWidth - collapsedSize) * inverse;
+    const height = collapsedSize + (expandedHeight - collapsedSize) * inverse;
+    const paddingY = expandedPaddingY * inverse;
+    const paddingX = expandedPaddingX * inverse;
+    const gap = expandedGap * inverse;
+    const radius = collapsedRadius * progress + expandedRadius * inverse;
+    const iconSize = collapsedIconSize * progress + expandedIconSize * inverse;
+    const iconShadow = progress > 0.8 ? collapsedIconShadow : expandedIconShadow;
+    const iconBg = progress > 0.8 ? collapsedIconBg : expandedIconBg;
+    const boxShadow = progress > 0.8 ? collapsedShadow : expandedShadow;
+    const justify = progress > 0.75 ? 'center' : expandedJustify;
+    toggle.style.setProperty('--wa-toggle-width', `${width}px`);
+    toggle.style.setProperty('--wa-toggle-height', `${height}px`);
+    toggle.style.setProperty('--wa-toggle-padding-y', `${paddingY}px`);
+    toggle.style.setProperty('--wa-toggle-padding-x', `${paddingX}px`);
+    toggle.style.setProperty('--wa-toggle-gap', `${gap}px`);
+    toggle.style.setProperty('--wa-toggle-radius', `${radius}px`);
+    toggle.style.setProperty('--wa-toggle-justify', justify);
+    toggle.style.boxShadow = boxShadow;
+    toggleIcon.style.setProperty('--wa-toggle-icon-size', `${iconSize}px`);
+    toggleIcon.style.setProperty('--wa-toggle-icon-shadow', iconShadow);
+    toggleIcon.style.setProperty('--wa-toggle-icon-bg', iconBg);
+    const copyOpacity = Math.max(0, Math.min(1, inverse * 1.2));
+    toggle.style.setProperty('--wa-toggle-copy-opacity', copyOpacity.toString());
+    const copyShift = `${-12 * progress}px`;
+    toggle.style.setProperty('--wa-toggle-copy-shift', copyShift);
+    toggle.style.setProperty('--wa-toggle-copy-visibility', progress > 0.98 ? 'hidden' : 'visible');
+    if(toggleCopy){
+      toggleCopy.style.pointerEvents = progress > 0.98 ? 'none' : '';
+    }
+    widget.classList.toggle('is-scrolled', progress > 0.02);
+  };
+
+  const scheduleProgress = (progress) => {
+    pendingProgress = Math.max(0, Math.min(1, progress));
+    if(frameId) return;
+    frameId = requestAnimationFrame(() => {
+      frameId = null;
+      applyProgress(pendingProgress);
+    });
+  };
+
+  const updateScrollState = () => {
+    if(toggle.getAttribute('aria-expanded') === 'true'){
+      scheduleProgress(0);
+      return;
+    }
+    const target = Math.max(0, Math.min(1, window.scrollY / collapseRange));
+    scheduleProgress(target);
+  };
+
+  captureExpandedMetrics();
 
   const openPanel = () => {
     if(panel.hasAttribute('data-closing')){
@@ -190,6 +339,7 @@ document.getElementById('next')?.addEventListener('click', function(e){
     requestAnimationFrame(() => {
       widget.classList.add('is-open');
       toggle.setAttribute('aria-expanded', 'true');
+      scheduleProgress(0);
       updateScrollState();
     });
   };
@@ -238,6 +388,20 @@ document.getElementById('next')?.addEventListener('click', function(e){
   });
 
   window.addEventListener('scroll', updateScrollState, {passive: true});
+  window.addEventListener('resize', () => {
+    const previousProgress = collapseProgress;
+    rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+    collapsedSize = 3.25 * rootFontSize;
+    collapsedIconSize = 2.4 * rootFontSize;
+    collapsedRadius = collapsedSize / 2;
+    captureExpandedMetrics();
+    scheduleProgress(toggle.getAttribute('aria-expanded') === 'true' ? 0 : previousProgress);
+  });
+  window.addEventListener('load', () => {
+    const previousProgress = collapseProgress;
+    captureExpandedMetrics();
+    scheduleProgress(toggle.getAttribute('aria-expanded') === 'true' ? 0 : previousProgress);
+  });
   updateScrollState();
 })();
 </script>

--- a/index.html
+++ b/index.html
@@ -371,16 +371,165 @@
   const panel = widget.querySelector('.whatsapp-panel');
   const closeBtn = widget.querySelector('.whatsapp-close');
   const cta = widget.querySelector('.whatsapp-panel__cta');
+  const toggleIcon = toggle.querySelector('.toggle-icon');
+  const toggleCopy = toggle.querySelector('.toggle-copy');
   const waLink = widget.getAttribute('data-wa-link');
 
   if(waLink && cta){
     cta.setAttribute('href', waLink);
   }
 
-  const updateScrollState = () => {
-    const shouldMinimize = window.scrollY > 40 && toggle.getAttribute('aria-expanded') === 'false';
-    widget.classList.toggle('is-scrolled', shouldMinimize);
+  const collapseRange = 180;
+  const collapsedShadow = '0 18px 36px rgba(18,140,126,.32)';
+  const collapsedIconShadow = '0 6px 14px rgba(0,0,0,.16)';
+  const collapsedIconBg = 'rgba(255,255,255,.18)';
+  let rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+  let collapsedSize = 3.25 * rootFontSize;
+  let collapsedIconSize = 2.4 * rootFontSize;
+  let collapsedRadius = collapsedSize / 2;
+  let expandedWidth = 0;
+  let expandedHeight = 0;
+  let expandedPaddingY = 0;
+  let expandedPaddingX = 0;
+  let expandedGap = 0;
+  let expandedRadius = 999;
+  let expandedShadow = getComputedStyle(toggle).boxShadow;
+  let expandedJustify = getComputedStyle(toggle).justifyContent || 'flex-start';
+  let expandedIconSize = 0;
+  let expandedIconShadow = getComputedStyle(toggleIcon).boxShadow;
+  let expandedIconBg = getComputedStyle(toggleIcon).backgroundColor;
+  let collapseProgress = 0;
+  let pendingProgress = 0;
+  let frameId = null;
+
+  const captureExpandedMetrics = () => {
+    const stored = {
+      width: toggle.style.getPropertyValue('--wa-toggle-width'),
+      height: toggle.style.getPropertyValue('--wa-toggle-height'),
+      paddingY: toggle.style.getPropertyValue('--wa-toggle-padding-y'),
+      paddingX: toggle.style.getPropertyValue('--wa-toggle-padding-x'),
+      gap: toggle.style.getPropertyValue('--wa-toggle-gap'),
+      radius: toggle.style.getPropertyValue('--wa-toggle-radius'),
+      justify: toggle.style.getPropertyValue('--wa-toggle-justify'),
+      copyOpacity: toggle.style.getPropertyValue('--wa-toggle-copy-opacity'),
+      copyShift: toggle.style.getPropertyValue('--wa-toggle-copy-shift'),
+      copyVisibility: toggle.style.getPropertyValue('--wa-toggle-copy-visibility'),
+      boxShadow: toggle.style.boxShadow,
+      iconSize: toggleIcon.style.getPropertyValue('--wa-toggle-icon-size'),
+      iconShadow: toggleIcon.style.getPropertyValue('--wa-toggle-icon-shadow'),
+      iconBg: toggleIcon.style.getPropertyValue('--wa-toggle-icon-bg'),
+      pointerEvents: toggleCopy ? toggleCopy.style.pointerEvents : undefined
+    };
+
+    toggle.style.removeProperty('--wa-toggle-width');
+    toggle.style.removeProperty('--wa-toggle-height');
+    toggle.style.removeProperty('--wa-toggle-padding-y');
+    toggle.style.removeProperty('--wa-toggle-padding-x');
+    toggle.style.removeProperty('--wa-toggle-gap');
+    toggle.style.removeProperty('--wa-toggle-radius');
+    toggle.style.removeProperty('--wa-toggle-justify');
+    toggle.style.removeProperty('--wa-toggle-copy-opacity');
+    toggle.style.removeProperty('--wa-toggle-copy-shift');
+    toggle.style.removeProperty('--wa-toggle-copy-visibility');
+    toggle.style.boxShadow = '';
+    toggleIcon.style.removeProperty('--wa-toggle-icon-size');
+    toggleIcon.style.removeProperty('--wa-toggle-icon-shadow');
+    toggleIcon.style.removeProperty('--wa-toggle-icon-bg');
+    if(toggleCopy){
+      toggleCopy.style.pointerEvents = '';
+    }
+
+    const toggleStyles = getComputedStyle(toggle);
+    const iconStyles = getComputedStyle(toggleIcon);
+    expandedJustify = toggleStyles.justifyContent || 'flex-start';
+    expandedShadow = toggleStyles.boxShadow;
+    expandedGap = parseFloat(toggleStyles.columnGap || toggleStyles.gap) || 0;
+    expandedPaddingY = parseFloat(toggleStyles.paddingTop) || 0;
+    expandedPaddingX = parseFloat(toggleStyles.paddingLeft) || 0;
+    expandedRadius = parseFloat(toggleStyles.borderTopLeftRadius) || 999;
+    const rect = toggle.getBoundingClientRect();
+    expandedWidth = rect.width;
+    expandedHeight = rect.height;
+    const iconRect = toggleIcon.getBoundingClientRect();
+    expandedIconSize = iconRect.width;
+    expandedIconShadow = iconStyles.boxShadow;
+    expandedIconBg = iconStyles.backgroundColor;
+
+    if(stored.width) toggle.style.setProperty('--wa-toggle-width', stored.width);
+    if(stored.height) toggle.style.setProperty('--wa-toggle-height', stored.height);
+    if(stored.paddingY) toggle.style.setProperty('--wa-toggle-padding-y', stored.paddingY);
+    if(stored.paddingX) toggle.style.setProperty('--wa-toggle-padding-x', stored.paddingX);
+    if(stored.gap) toggle.style.setProperty('--wa-toggle-gap', stored.gap);
+    if(stored.radius) toggle.style.setProperty('--wa-toggle-radius', stored.radius);
+    if(stored.justify) toggle.style.setProperty('--wa-toggle-justify', stored.justify);
+    if(stored.copyOpacity) toggle.style.setProperty('--wa-toggle-copy-opacity', stored.copyOpacity);
+    if(stored.copyShift) toggle.style.setProperty('--wa-toggle-copy-shift', stored.copyShift);
+    if(stored.copyVisibility) toggle.style.setProperty('--wa-toggle-copy-visibility', stored.copyVisibility);
+    if(stored.boxShadow) toggle.style.boxShadow = stored.boxShadow;
+    if(stored.iconSize) toggleIcon.style.setProperty('--wa-toggle-icon-size', stored.iconSize);
+    if(stored.iconShadow) toggleIcon.style.setProperty('--wa-toggle-icon-shadow', stored.iconShadow);
+    if(stored.iconBg) toggleIcon.style.setProperty('--wa-toggle-icon-bg', stored.iconBg);
+    if(toggleCopy && stored.pointerEvents !== undefined){
+      toggleCopy.style.pointerEvents = stored.pointerEvents;
+    }
   };
+
+  const applyProgress = (progress) => {
+    collapseProgress = progress;
+    widget.style.setProperty('--wa-collapse-progress', progress.toFixed(3));
+    const inverse = 1 - progress;
+    const width = collapsedSize + (expandedWidth - collapsedSize) * inverse;
+    const height = collapsedSize + (expandedHeight - collapsedSize) * inverse;
+    const paddingY = expandedPaddingY * inverse;
+    const paddingX = expandedPaddingX * inverse;
+    const gap = expandedGap * inverse;
+    const radius = collapsedRadius * progress + expandedRadius * inverse;
+    const iconSize = collapsedIconSize * progress + expandedIconSize * inverse;
+    const iconShadow = progress > 0.8 ? collapsedIconShadow : expandedIconShadow;
+    const iconBg = progress > 0.8 ? collapsedIconBg : expandedIconBg;
+    const boxShadow = progress > 0.8 ? collapsedShadow : expandedShadow;
+    const justify = progress > 0.75 ? 'center' : expandedJustify;
+    toggle.style.setProperty('--wa-toggle-width', `${width}px`);
+    toggle.style.setProperty('--wa-toggle-height', `${height}px`);
+    toggle.style.setProperty('--wa-toggle-padding-y', `${paddingY}px`);
+    toggle.style.setProperty('--wa-toggle-padding-x', `${paddingX}px`);
+    toggle.style.setProperty('--wa-toggle-gap', `${gap}px`);
+    toggle.style.setProperty('--wa-toggle-radius', `${radius}px`);
+    toggle.style.setProperty('--wa-toggle-justify', justify);
+    toggle.style.boxShadow = boxShadow;
+    toggleIcon.style.setProperty('--wa-toggle-icon-size', `${iconSize}px`);
+    toggleIcon.style.setProperty('--wa-toggle-icon-shadow', iconShadow);
+    toggleIcon.style.setProperty('--wa-toggle-icon-bg', iconBg);
+    const copyOpacity = Math.max(0, Math.min(1, inverse * 1.2));
+    toggle.style.setProperty('--wa-toggle-copy-opacity', copyOpacity.toString());
+    const copyShift = `${-12 * progress}px`;
+    toggle.style.setProperty('--wa-toggle-copy-shift', copyShift);
+    toggle.style.setProperty('--wa-toggle-copy-visibility', progress > 0.98 ? 'hidden' : 'visible');
+    if(toggleCopy){
+      toggleCopy.style.pointerEvents = progress > 0.98 ? 'none' : '';
+    }
+    widget.classList.toggle('is-scrolled', progress > 0.02);
+  };
+
+  const scheduleProgress = (progress) => {
+    pendingProgress = Math.max(0, Math.min(1, progress));
+    if(frameId) return;
+    frameId = requestAnimationFrame(() => {
+      frameId = null;
+      applyProgress(pendingProgress);
+    });
+  };
+
+  const updateScrollState = () => {
+    if(toggle.getAttribute('aria-expanded') === 'true'){
+      scheduleProgress(0);
+      return;
+    }
+    const target = Math.max(0, Math.min(1, window.scrollY / collapseRange));
+    scheduleProgress(target);
+  };
+
+  captureExpandedMetrics();
 
   const openPanel = () => {
     if(panel.hasAttribute('data-closing')){
@@ -391,6 +540,7 @@
     requestAnimationFrame(() => {
       widget.classList.add('is-open');
       toggle.setAttribute('aria-expanded', 'true');
+      scheduleProgress(0);
       updateScrollState();
     });
   };
@@ -439,6 +589,20 @@
   });
 
   window.addEventListener('scroll', updateScrollState, {passive: true});
+  window.addEventListener('resize', () => {
+    const previousProgress = collapseProgress;
+    rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+    collapsedSize = 3.25 * rootFontSize;
+    collapsedIconSize = 2.4 * rootFontSize;
+    collapsedRadius = collapsedSize / 2;
+    captureExpandedMetrics();
+    scheduleProgress(toggle.getAttribute('aria-expanded') === 'true' ? 0 : previousProgress);
+  });
+  window.addEventListener('load', () => {
+    const previousProgress = collapseProgress;
+    captureExpandedMetrics();
+    scheduleProgress(toggle.getAttribute('aria-expanded') === 'true' ? 0 : previousProgress);
+  });
   updateScrollState();
 })();
 </script>

--- a/styles.css
+++ b/styles.css
@@ -182,13 +182,13 @@ h2{font-size:clamp(1.4rem, 1.3vw + 1.2rem, 2.1rem); margin:0 0 .85rem;font-weigh
 hr.sep{border:0;border-top:1px solid #e6eaee;margin:1.75rem 0}
 
 /* whatsapp widget */
-.whatsapp-widget{position:fixed;right:26px;bottom:26px;z-index:120;display:flex;flex-direction:column;align-items:flex-end;gap:.9rem;font-family:"Satoshi",Arial,sans-serif}
-.whatsapp-widget .whatsapp-toggle{border:0;border-radius:999px;padding:.75rem 1.15rem;background:linear-gradient(135deg,#25D366,#128C7E);color:#fff;display:flex;align-items:center;gap:.7rem;font-weight:650;letter-spacing:-.01em;box-shadow:0 20px 44px rgba(18,140,126,.28),0 0 0 1px rgba(255,255,255,.3) inset;cursor:pointer;transition:transform .35s ease, box-shadow .35s ease, padding .3s ease, width .3s ease, height .3s ease, border-radius .3s ease, gap .3s ease}
+.whatsapp-widget{position:fixed;right:26px;bottom:26px;z-index:120;display:flex;flex-direction:column;align-items:flex-end;gap:.9rem;font-family:"Satoshi",Arial,sans-serif;--wa-collapse-progress:0}
+.whatsapp-widget .whatsapp-toggle{border:0;border-radius:999px;padding:.75rem 1.15rem;background:linear-gradient(135deg,#25D366,#128C7E);color:#fff;display:flex;align-items:center;gap:.7rem;font-weight:650;letter-spacing:-.01em;box-shadow:0 20px 44px rgba(18,140,126,.28),0 0 0 1px rgba(255,255,255,.3) inset;cursor:pointer;transition:transform .35s ease, box-shadow .35s ease;justify-content:var(--wa-toggle-justify,flex-start);padding:var(--wa-toggle-padding-y,.75rem) var(--wa-toggle-padding-x,1.15rem);width:var(--wa-toggle-width,auto);height:var(--wa-toggle-height,auto);gap:var(--wa-toggle-gap,.7rem);border-radius:var(--wa-toggle-radius,999px)}
 .whatsapp-widget .whatsapp-toggle:focus-visible{outline:3px solid rgba(37,211,102,.55);outline-offset:3px}
 .whatsapp-widget .whatsapp-toggle:hover{transform:translateY(-2px) scale(1.02);box-shadow:0 28px 58px rgba(18,140,126,.36)}
-.whatsapp-widget .toggle-icon{width:38px;height:38px;border-radius:50%;display:grid;place-items:center;background:rgba(255,255,255,.22);box-shadow:0 12px 20px rgba(10,20,30,.25) inset,0 4px 10px rgba(0,0,0,.18);transition:width .3s ease, height .3s ease, box-shadow .3s ease, background .3s ease}
+.whatsapp-widget .toggle-icon{width:var(--wa-toggle-icon-size,38px);height:var(--wa-toggle-icon-size,38px);border-radius:50%;display:grid;place-items:center;background:var(--wa-toggle-icon-bg,rgba(255,255,255,.22));box-shadow:var(--wa-toggle-icon-shadow,0 12px 20px rgba(10,20,30,.25) inset,0 4px 10px rgba(0,0,0,.18));transition:transform .3s ease}
 .whatsapp-widget .toggle-icon svg{width:22px;height:22px;display:block}
-.whatsapp-widget .toggle-copy{display:grid;gap:.1rem;text-align:left}
+.whatsapp-widget .toggle-copy{display:grid;gap:.1rem;text-align:left;opacity:var(--wa-toggle-copy-opacity,1);transform:translateX(var(--wa-toggle-copy-shift,0));visibility:var(--wa-toggle-copy-visibility,visible);transition:opacity .2s ease}
 .whatsapp-widget .toggle-copy strong{font-size:.98rem;line-height:1;font-weight:650;transition:opacity .25s ease}
 .whatsapp-widget .toggle-copy span{font-size:.78rem;letter-spacing:.04em;text-transform:uppercase;color:rgba(255,255,255,.76);font-weight:600;transition:opacity .25s ease}
 .whatsapp-panel{width:min(320px,calc(100vw - 2.4rem));border-radius:22px;background:linear-gradient(150deg,rgba(18,140,126,.96),rgba(37,211,102,.88));color:#f4fff8;box-shadow:0 32px 60px rgba(18,140,126,.35);border:1px solid rgba(255,255,255,.35);overflow:hidden;transform-origin:bottom right;opacity:0;transform:translateY(12px) scale(.96);pointer-events:none;transition:opacity .28s ease, transform .32s cubic-bezier(.2,.8,.2,1)}
@@ -208,9 +208,6 @@ hr.sep{border:0;border-top:1px solid #e6eaee;margin:1.75rem 0}
 .whatsapp-panel__cta:focus-visible{outline:3px solid rgba(255,255,255,.65);outline-offset:3px}
 .whatsapp-panel__note{font-size:.75rem;color:rgba(244,255,248,.78);line-height:1.4}
 .whatsapp-panel__note a{color:#fff;font-weight:600}
-.whatsapp-widget.is-scrolled:not(.is-open) .whatsapp-toggle{padding:0;width:3.25rem;height:3.25rem;gap:0;border-radius:50%;justify-content:center;box-shadow:0 18px 36px rgba(18,140,126,.32)}
-.whatsapp-widget.is-scrolled:not(.is-open) .toggle-icon{width:2.4rem;height:2.4rem;background:rgba(255,255,255,.18);box-shadow:0 6px 14px rgba(0,0,0,.16)}
-.whatsapp-widget.is-scrolled:not(.is-open) .toggle-copy{display:none}
 
 /* responsive */
 @media (max-width: 1040px){


### PR DESCRIPTION
## Summary
- drive the WhatsApp widget toggle animation using scroll progress for both pages
- capture toggle measurements and update CSS variables for smooth size transitions
- adjust widget styles to support variable-driven layout changes during collapse

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9ea83c1208325b3916e896a66e985