### PR TITLE
Refresh WhatsApp widget visuals and behavior

### DIFF
--- a/assets/whatsapp-widget.js
+++ b/assets/whatsapp-widget.js
@@ -1,0 +1,281 @@
+(function(){
+  const widget = document.querySelector('.whatsapp-widget');
+  if(!widget) return;
+
+  const toggle = widget.querySelector('.whatsapp-toggle');
+  const panel = widget.querySelector('.whatsapp-panel');
+  const closeBtn = widget.querySelector('.whatsapp-close');
+  const cta = widget.querySelector('.whatsapp-panel__cta');
+  const toggleIcon = toggle.querySelector('.toggle-icon');
+  const toggleCopy = toggle.querySelector('.toggle-copy');
+  const waLink = widget.getAttribute('data-wa-link');
+
+  if(waLink && cta){
+    cta.setAttribute('href', waLink);
+  }
+
+  const collapseRange = 180;
+  const collapsedShadow = '0 18px 36px rgba(18,140,126,.32)';
+  const collapsedIconShadow = '0 6px 14px rgba(0,0,0,.16)';
+  const collapsedIconBg = 'rgba(255,255,255,.18)';
+  let rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+  let collapsedSize = 3.25 * rootFontSize;
+  let collapsedIconSize = 2.4 * rootFontSize;
+  let collapsedRadius = collapsedSize / 2;
+  let expandedWidth = 0;
+  let expandedHeight = 0;
+  let expandedPaddingY = 0;
+  let expandedPaddingX = 0;
+  let expandedGap = 0;
+  let expandedRadius = 999;
+  let expandedShadow = getComputedStyle(toggle).boxShadow;
+  let expandedJustify = getComputedStyle(toggle).justifyContent || 'flex-start';
+  let expandedIconSize = 0;
+  let expandedIconShadow = getComputedStyle(toggleIcon).boxShadow;
+  let expandedIconBg = getComputedStyle(toggleIcon).backgroundColor;
+  let collapseProgress = 0;
+  let pendingProgress = 0;
+  let frameId = null;
+
+  const collapseQuery = window.matchMedia('(max-width: 640px)');
+  let collapseActive = !collapseQuery.matches;
+
+  function clearProgressStyles(){
+    widget.style.removeProperty('--wa-collapse-progress');
+    toggle.style.removeProperty('--wa-toggle-width');
+    toggle.style.removeProperty('--wa-toggle-height');
+    toggle.style.removeProperty('--wa-toggle-padding-y');
+    toggle.style.removeProperty('--wa-toggle-padding-x');
+    toggle.style.removeProperty('--wa-toggle-gap');
+    toggle.style.removeProperty('--wa-toggle-radius');
+    toggle.style.removeProperty('--wa-toggle-justify');
+    toggle.style.removeProperty('--wa-toggle-copy-opacity');
+    toggle.style.removeProperty('--wa-toggle-copy-shift');
+    toggle.style.removeProperty('--wa-toggle-copy-visibility');
+    toggle.style.boxShadow = '';
+    toggleIcon.style.removeProperty('--wa-toggle-icon-size');
+    toggleIcon.style.removeProperty('--wa-toggle-icon-shadow');
+    toggleIcon.style.removeProperty('--wa-toggle-icon-bg');
+    if(toggleCopy){
+      toggleCopy.style.pointerEvents = '';
+    }
+  }
+
+  function captureExpandedMetrics(){
+    const stored = {
+      width: toggle.style.getPropertyValue('--wa-toggle-width'),
+      height: toggle.style.getPropertyValue('--wa-toggle-height'),
+      paddingY: toggle.style.getPropertyValue('--wa-toggle-padding-y'),
+      paddingX: toggle.style.getPropertyValue('--wa-toggle-padding-x'),
+      gap: toggle.style.getPropertyValue('--wa-toggle-gap'),
+      radius: toggle.style.getPropertyValue('--wa-toggle-radius'),
+      justify: toggle.style.getPropertyValue('--wa-toggle-justify'),
+      copyOpacity: toggle.style.getPropertyValue('--wa-toggle-copy-opacity'),
+      copyShift: toggle.style.getPropertyValue('--wa-toggle-copy-shift'),
+      copyVisibility: toggle.style.getPropertyValue('--wa-toggle-copy-visibility'),
+      boxShadow: toggle.style.boxShadow,
+      iconSize: toggleIcon.style.getPropertyValue('--wa-toggle-icon-size'),
+      iconShadow: toggleIcon.style.getPropertyValue('--wa-toggle-icon-shadow'),
+      iconBg: toggleIcon.style.getPropertyValue('--wa-toggle-icon-bg'),
+      pointerEvents: toggleCopy ? toggleCopy.style.pointerEvents : undefined
+    };
+
+    clearProgressStyles();
+
+    const toggleStyles = getComputedStyle(toggle);
+    const iconStyles = getComputedStyle(toggleIcon);
+    expandedJustify = toggleStyles.justifyContent || 'flex-start';
+    expandedShadow = toggleStyles.boxShadow;
+    expandedGap = parseFloat(toggleStyles.columnGap || toggleStyles.gap) || 0;
+    expandedPaddingY = parseFloat(toggleStyles.paddingTop) || 0;
+    expandedPaddingX = parseFloat(toggleStyles.paddingLeft) || 0;
+    expandedRadius = parseFloat(toggleStyles.borderTopLeftRadius) || 999;
+    const rect = toggle.getBoundingClientRect();
+    expandedWidth = rect.width;
+    expandedHeight = rect.height;
+    const iconRect = toggleIcon.getBoundingClientRect();
+    expandedIconSize = iconRect.width;
+    expandedIconShadow = iconStyles.boxShadow;
+    expandedIconBg = iconStyles.backgroundColor;
+
+    if(stored.width) toggle.style.setProperty('--wa-toggle-width', stored.width);
+    if(stored.height) toggle.style.setProperty('--wa-toggle-height', stored.height);
+    if(stored.paddingY) toggle.style.setProperty('--wa-toggle-padding-y', stored.paddingY);
+    if(stored.paddingX) toggle.style.setProperty('--wa-toggle-padding-x', stored.paddingX);
+    if(stored.gap) toggle.style.setProperty('--wa-toggle-gap', stored.gap);
+    if(stored.radius) toggle.style.setProperty('--wa-toggle-radius', stored.radius);
+    if(stored.justify) toggle.style.setProperty('--wa-toggle-justify', stored.justify);
+    if(stored.copyOpacity) toggle.style.setProperty('--wa-toggle-copy-opacity', stored.copyOpacity);
+    if(stored.copyShift) toggle.style.setProperty('--wa-toggle-copy-shift', stored.copyShift);
+    if(stored.copyVisibility) toggle.style.setProperty('--wa-toggle-copy-visibility', stored.copyVisibility);
+    if(stored.boxShadow) toggle.style.boxShadow = stored.boxShadow;
+    if(stored.iconSize) toggleIcon.style.setProperty('--wa-toggle-icon-size', stored.iconSize);
+    if(stored.iconShadow) toggleIcon.style.setProperty('--wa-toggle-icon-shadow', stored.iconShadow);
+    if(stored.iconBg) toggleIcon.style.setProperty('--wa-toggle-icon-bg', stored.iconBg);
+    if(toggleCopy && stored.pointerEvents !== undefined){
+      toggleCopy.style.pointerEvents = stored.pointerEvents;
+    }
+  }
+
+  function applyProgress(progress){
+    if(!collapseActive){
+      clearProgressStyles();
+      widget.classList.remove('is-scrolled');
+      collapseProgress = 0;
+      return;
+    }
+
+    collapseProgress = progress;
+    widget.style.setProperty('--wa-collapse-progress', progress.toFixed(3));
+    const inverse = 1 - progress;
+    const width = collapsedSize + (expandedWidth - collapsedSize) * inverse;
+    const height = collapsedSize + (expandedHeight - collapsedSize) * inverse;
+    const paddingY = expandedPaddingY * inverse;
+    const paddingX = expandedPaddingX * inverse;
+    const gap = expandedGap * inverse;
+    const radius = collapsedRadius * progress + expandedRadius * inverse;
+    const iconSize = collapsedIconSize * progress + expandedIconSize * inverse;
+    const iconShadow = progress > 0.8 ? collapsedIconShadow : expandedIconShadow;
+    const iconBg = progress > 0.8 ? collapsedIconBg : expandedIconBg;
+    const boxShadow = progress > 0.8 ? collapsedShadow : expandedShadow;
+    const justify = progress > 0.75 ? 'center' : expandedJustify;
+
+    toggle.style.setProperty('--wa-toggle-width', `${width}px`);
+    toggle.style.setProperty('--wa-toggle-height', `${height}px`);
+    toggle.style.setProperty('--wa-toggle-padding-y', `${paddingY}px`);
+    toggle.style.setProperty('--wa-toggle-padding-x', `${paddingX}px`);
+    toggle.style.setProperty('--wa-toggle-gap', `${gap}px`);
+    toggle.style.setProperty('--wa-toggle-radius', `${radius}px`);
+    toggle.style.setProperty('--wa-toggle-justify', justify);
+    toggle.style.boxShadow = boxShadow;
+    toggleIcon.style.setProperty('--wa-toggle-icon-size', `${iconSize}px`);
+    toggleIcon.style.setProperty('--wa-toggle-icon-shadow', iconShadow);
+    toggleIcon.style.setProperty('--wa-toggle-icon-bg', iconBg);
+    const copyOpacity = Math.max(0, Math.min(1, inverse * 1.2));
+    toggle.style.setProperty('--wa-toggle-copy-opacity', copyOpacity.toString());
+    const copyShift = `${-12 * progress}px`;
+    toggle.style.setProperty('--wa-toggle-copy-shift', copyShift);
+    toggle.style.setProperty('--wa-toggle-copy-visibility', progress > 0.98 ? 'hidden' : 'visible');
+    if(toggleCopy){
+      toggleCopy.style.pointerEvents = progress > 0.98 ? 'none' : '';
+    }
+    widget.classList.toggle('is-scrolled', progress > 0.02);
+  }
+
+  function scheduleProgress(progress){
+    pendingProgress = collapseActive ? Math.max(0, Math.min(1, progress)) : 0;
+    if(frameId) return;
+    frameId = requestAnimationFrame(() => {
+      frameId = null;
+      applyProgress(pendingProgress);
+    });
+  }
+
+  function updateScrollState(){
+    if(!collapseActive){
+      scheduleProgress(0);
+      return;
+    }
+    if(toggle.getAttribute('aria-expanded') === 'true'){
+      scheduleProgress(0);
+      return;
+    }
+    const target = Math.max(0, Math.min(1, window.scrollY / collapseRange));
+    scheduleProgress(target);
+  }
+
+  function syncCollapseMode(){
+    collapseActive = !collapseQuery.matches;
+    if(!collapseActive){
+      collapseProgress = 0;
+      pendingProgress = 0;
+      if(frameId){
+        cancelAnimationFrame(frameId);
+        frameId = null;
+      }
+      clearProgressStyles();
+      widget.classList.remove('is-scrolled');
+      return;
+    }
+    captureExpandedMetrics();
+    updateScrollState();
+  }
+
+  if(collapseQuery.addEventListener){
+    collapseQuery.addEventListener('change', syncCollapseMode);
+  } else if(collapseQuery.addListener){
+    collapseQuery.addListener(syncCollapseMode);
+  }
+
+  function openPanel(){
+    if(panel.hasAttribute('data-closing')){
+      panel.removeAttribute('data-closing');
+    }
+    panel.hidden = false;
+    panel.setAttribute('aria-hidden', 'false');
+    requestAnimationFrame(() => {
+      widget.classList.add('is-open');
+      toggle.setAttribute('aria-expanded', 'true');
+      scheduleProgress(0);
+      updateScrollState();
+    });
+  }
+
+  function closePanel(){
+    widget.classList.remove('is-open');
+    toggle.setAttribute('aria-expanded', 'false');
+    panel.setAttribute('aria-hidden', 'true');
+    panel.setAttribute('data-closing', 'true');
+    updateScrollState();
+    setTimeout(() => {
+      if(panel.getAttribute('data-closing') === 'true'){
+        panel.hidden = true;
+        panel.removeAttribute('data-closing');
+      }
+    }, 220);
+  }
+
+  toggle.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    if(expanded){
+      closePanel();
+    } else {
+      openPanel();
+    }
+  });
+
+  closeBtn.addEventListener('click', closePanel);
+
+  if(cta){
+    cta.addEventListener('click', () => {
+      closePanel();
+    });
+  }
+
+  document.addEventListener('click', (event) => {
+    if(!widget.contains(event.target) && toggle.getAttribute('aria-expanded') === 'true'){
+      closePanel();
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if(event.key === 'Escape' && toggle.getAttribute('aria-expanded') === 'true'){
+      closePanel();
+    }
+  });
+
+  window.addEventListener('scroll', updateScrollState, {passive: true});
+  window.addEventListener('resize', () => {
+    rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+    collapsedSize = 3.25 * rootFontSize;
+    collapsedIconSize = 2.4 * rootFontSize;
+    collapsedRadius = collapsedSize / 2;
+    syncCollapseMode();
+  });
+
+  window.addEventListener('load', () => {
+    syncCollapseMode();
+  });
+
+  syncCollapseMode();
+})();

--- a/contact.html
+++ b/contact.html
@@ -119,7 +119,13 @@ select.input{appearance:none;background:rgba(255,255,255,.82);background-image:l
 <div class="whatsapp-widget" data-wa-link="https://wa.me/94723652618">
   <div class="whatsapp-panel" id="whatsapp-panel" hidden aria-hidden="true">
     <div class="whatsapp-panel__header">
-      <div class="whatsapp-panel__avatar" aria-hidden="true">💬</div>
+      <div class="whatsapp-panel__avatar" aria-hidden="true">
+        <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" focusable="false" role="img" aria-hidden="true">
+          <circle cx="24" cy="24" r="22" fill="#25D366"/>
+          <path d="M24 12c-6.63 0-12 4.94-12 11.03 0 2.62 1.05 5.08 2.89 6.99l-1.2 4.39 4.52-1.18c1.56.43 2.95.6 5.79.6 6.63 0 12-4.94 12-11.03C36 16.94 30.63 12 24 12z" fill="#fff"/>
+          <path d="M19.46 18.24c-.28-.62-.57-.63-.84-.63-.22 0-.45 0-.66 0-.23 0-.6.09-.91.43-.31.34-1.2 1.17-1.2 2.85 0 1.68 1.23 3.3 1.4 3.52.17.22 2.37 3.65 5.87 5.07 2.9 1.2 3.49.96 4.13.9.63-.06 2.03-.82 2.32-1.64.29-.82.29-1.53.2-1.68-.09-.15-.34-.24-.72-.42-.38-.18-2.27-1.11-2.62-1.23-.35-.12-.61-.18-.87.18-.26.36-1 1.23-1.23 1.49-.23.26-.45.28-.83.09-.38-.18-1.61-.59-3.07-1.88-1.14-1.01-1.91-2.26-2.14-2.63-.22-.36-.02-.55.17-.73.17-.17.38-.45.57-.68.18-.23.24-.39.36-.65.12-.26.06-.48-.03-.66-.09-.18-.82-2.01-1.13-2.73z" fill="#128C7E"/>
+        </svg>
+      </div>
       <div class="whatsapp-panel__title">
         <strong>Capital Connect LK</strong>
         <span class="whatsapp-panel__status">We're online</span>
@@ -135,15 +141,9 @@ select.input{appearance:none;background:rgba(255,255,255,.82);background-image:l
   <button class="whatsapp-toggle" type="button" aria-expanded="false" aria-controls="whatsapp-panel">
     <span class="toggle-icon" aria-hidden="true">
       <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" role="img" aria-hidden="true">
-        <defs>
-          <linearGradient id="waGradientToggle" x1="8" y1="8" x2="40" y2="40" gradientUnits="userSpaceOnUse">
-            <stop offset="0" stop-color="#25D366"/>
-            <stop offset="1" stop-color="#128C7E"/>
-          </linearGradient>
-        </defs>
-        <circle cx="24" cy="24" r="22" fill="url(#waGradientToggle)"/>
-        <path d="M24 12c-6.63 0-12 4.94-12 11.03 0 2.62 1.05 5.08 2.89 6.99l-1.2 4.39 4.52-1.18c1.56.43 2.95.6 5.79.6 6.63 0 12-4.94 12-11.03C36 16.94 30.63 12 24 12z" fill="#fff" fill-opacity=".98"/>
-        <path d="M19.46 18.24c-.28-.62-.57-.63-.84-.63-.22 0-.45 0-.66 0-.23 0-.6.09-.91.43-.31.34-1.2 1.17-1.2 2.85 0 1.68 1.23 3.3 1.4 3.52.17.22 2.37 3.65 5.87 5.07 2.9 1.2 3.49.96 4.13.9.63-.06 2.03-.82 2.32-1.64.29-.82.29-1.53.2-1.68-.09-.15-.34-.24-.72-.42-.38-.18-2.27-1.11-2.62-1.23-.35-.12-.61-.18-.87.18-.26.36-1 1.23-1.23 1.49-.23.26-.45.28-.83.09-.38-.18-1.61-.59-3.07-1.88-1.14-1.01-1.91-2.26-2.14-2.63-.22-.36-.02-.55.17-.73.17-.17.38-.45.57-.68.18-.23.24-.39.36-.65.12-.26.06-.48-.03-.66-.09-.18-.82-2.01-1.13-2.73z" fill="url(#waGradientToggle)"/>
+        <circle cx="24" cy="24" r="22" fill="#25D366"/>
+        <path d="M24 12c-6.63 0-12 4.94-12 11.03 0 2.62 1.05 5.08 2.89 6.99l-1.2 4.39 4.52-1.18c1.56.43 2.95.6 5.79.6 6.63 0 12-4.94 12-11.03C36 16.94 30.63 12 24 12z" fill="#fff"/>
+        <path d="M19.46 18.24c-.28-.62-.57-.63-.84-.63-.22 0-.45 0-.66 0-.23 0-.6.09-.91.43-.31.34-1.2 1.17-1.2 2.85 0 1.68 1.23 3.3 1.4 3.52.17.22 2.37 3.65 5.87 5.07 2.9 1.2 3.49.96 4.13.9.63-.06 2.03-.82 2.32-1.64.29-.82.29-1.53.2-1.68-.09-.15-.34-.24-.72-.42-.38-.18-2.27-1.11-2.62-1.23-.35-.12-.61-.18-.87.18-.26.36-1 1.23-1.23 1.49-.23.26-.45.28-.83.09-.38-.18-1.61-.59-3.07-1.88-1.14-1.01-1.91-2.26-2.14-2.63-.22-.36-.02-.55.17-.73.17-.17.38-.45.57-.68.18-.23.24-.39.36-.65.12-.26.06-.48-.03-.66-.09-.18-.82-2.01-1.13-2.73z" fill="#128C7E"/>
       </svg>
     </span>
     <span class="toggle-copy">
@@ -162,249 +162,7 @@ document.getElementById('next')?.addEventListener('click', function(e){
 });
 </script>
 
-<script>
-(function(){
-  const widget = document.querySelector('.whatsapp-widget');
-  if(!widget) return;
-  const toggle = widget.querySelector('.whatsapp-toggle');
-  const panel = widget.querySelector('.whatsapp-panel');
-  const closeBtn = widget.querySelector('.whatsapp-close');
-  const cta = widget.querySelector('.whatsapp-panel__cta');
-  const toggleIcon = toggle.querySelector('.toggle-icon');
-  const toggleCopy = toggle.querySelector('.toggle-copy');
-  const waLink = widget.getAttribute('data-wa-link');
-
-  if(waLink && cta){
-    cta.setAttribute('href', waLink);
-  }
-
-  const collapseRange = 180;
-  const collapsedShadow = '0 18px 36px rgba(18,140,126,.32)';
-  const collapsedIconShadow = '0 6px 14px rgba(0,0,0,.16)';
-  const collapsedIconBg = 'rgba(255,255,255,.18)';
-  let rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
-  let collapsedSize = 3.25 * rootFontSize;
-  let collapsedIconSize = 2.4 * rootFontSize;
-  let collapsedRadius = collapsedSize / 2;
-  let expandedWidth = 0;
-  let expandedHeight = 0;
-  let expandedPaddingY = 0;
-  let expandedPaddingX = 0;
-  let expandedGap = 0;
-  let expandedRadius = 999;
-  let expandedShadow = getComputedStyle(toggle).boxShadow;
-  let expandedJustify = getComputedStyle(toggle).justifyContent || 'flex-start';
-  let expandedIconSize = 0;
-  let expandedIconShadow = getComputedStyle(toggleIcon).boxShadow;
-  let expandedIconBg = getComputedStyle(toggleIcon).backgroundColor;
-  let collapseProgress = 0;
-  let pendingProgress = 0;
-  let frameId = null;
-
-  const captureExpandedMetrics = () => {
-    const stored = {
-      width: toggle.style.getPropertyValue('--wa-toggle-width'),
-      height: toggle.style.getPropertyValue('--wa-toggle-height'),
-      paddingY: toggle.style.getPropertyValue('--wa-toggle-padding-y'),
-      paddingX: toggle.style.getPropertyValue('--wa-toggle-padding-x'),
-      gap: toggle.style.getPropertyValue('--wa-toggle-gap'),
-      radius: toggle.style.getPropertyValue('--wa-toggle-radius'),
-      justify: toggle.style.getPropertyValue('--wa-toggle-justify'),
-      copyOpacity: toggle.style.getPropertyValue('--wa-toggle-copy-opacity'),
-      copyShift: toggle.style.getPropertyValue('--wa-toggle-copy-shift'),
-      copyVisibility: toggle.style.getPropertyValue('--wa-toggle-copy-visibility'),
-      boxShadow: toggle.style.boxShadow,
-      iconSize: toggleIcon.style.getPropertyValue('--wa-toggle-icon-size'),
-      iconShadow: toggleIcon.style.getPropertyValue('--wa-toggle-icon-shadow'),
-      iconBg: toggleIcon.style.getPropertyValue('--wa-toggle-icon-bg'),
-      pointerEvents: toggleCopy ? toggleCopy.style.pointerEvents : undefined
-    };
-
-    toggle.style.removeProperty('--wa-toggle-width');
-    toggle.style.removeProperty('--wa-toggle-height');
-    toggle.style.removeProperty('--wa-toggle-padding-y');
-    toggle.style.removeProperty('--wa-toggle-padding-x');
-    toggle.style.removeProperty('--wa-toggle-gap');
-    toggle.style.removeProperty('--wa-toggle-radius');
-    toggle.style.removeProperty('--wa-toggle-justify');
-    toggle.style.removeProperty('--wa-toggle-copy-opacity');
-    toggle.style.removeProperty('--wa-toggle-copy-shift');
-    toggle.style.removeProperty('--wa-toggle-copy-visibility');
-    toggle.style.boxShadow = '';
-    toggleIcon.style.removeProperty('--wa-toggle-icon-size');
-    toggleIcon.style.removeProperty('--wa-toggle-icon-shadow');
-    toggleIcon.style.removeProperty('--wa-toggle-icon-bg');
-    if(toggleCopy){
-      toggleCopy.style.pointerEvents = '';
-    }
-
-    const toggleStyles = getComputedStyle(toggle);
-    const iconStyles = getComputedStyle(toggleIcon);
-    expandedJustify = toggleStyles.justifyContent || 'flex-start';
-    expandedShadow = toggleStyles.boxShadow;
-    expandedGap = parseFloat(toggleStyles.columnGap || toggleStyles.gap) || 0;
-    expandedPaddingY = parseFloat(toggleStyles.paddingTop) || 0;
-    expandedPaddingX = parseFloat(toggleStyles.paddingLeft) || 0;
-    expandedRadius = parseFloat(toggleStyles.borderTopLeftRadius) || 999;
-    const rect = toggle.getBoundingClientRect();
-    expandedWidth = rect.width;
-    expandedHeight = rect.height;
-    const iconRect = toggleIcon.getBoundingClientRect();
-    expandedIconSize = iconRect.width;
-    expandedIconShadow = iconStyles.boxShadow;
-    expandedIconBg = iconStyles.backgroundColor;
-
-    if(stored.width) toggle.style.setProperty('--wa-toggle-width', stored.width);
-    if(stored.height) toggle.style.setProperty('--wa-toggle-height', stored.height);
-    if(stored.paddingY) toggle.style.setProperty('--wa-toggle-padding-y', stored.paddingY);
-    if(stored.paddingX) toggle.style.setProperty('--wa-toggle-padding-x', stored.paddingX);
-    if(stored.gap) toggle.style.setProperty('--wa-toggle-gap', stored.gap);
-    if(stored.radius) toggle.style.setProperty('--wa-toggle-radius', stored.radius);
-    if(stored.justify) toggle.style.setProperty('--wa-toggle-justify', stored.justify);
-    if(stored.copyOpacity) toggle.style.setProperty('--wa-toggle-copy-opacity', stored.copyOpacity);
-    if(stored.copyShift) toggle.style.setProperty('--wa-toggle-copy-shift', stored.copyShift);
-    if(stored.copyVisibility) toggle.style.setProperty('--wa-toggle-copy-visibility', stored.copyVisibility);
-    if(stored.boxShadow) toggle.style.boxShadow = stored.boxShadow;
-    if(stored.iconSize) toggleIcon.style.setProperty('--wa-toggle-icon-size', stored.iconSize);
-    if(stored.iconShadow) toggleIcon.style.setProperty('--wa-toggle-icon-shadow', stored.iconShadow);
-    if(stored.iconBg) toggleIcon.style.setProperty('--wa-toggle-icon-bg', stored.iconBg);
-    if(toggleCopy && stored.pointerEvents !== undefined){
-      toggleCopy.style.pointerEvents = stored.pointerEvents;
-    }
-  };
-
-  const applyProgress = (progress) => {
-    collapseProgress = progress;
-    widget.style.setProperty('--wa-collapse-progress', progress.toFixed(3));
-    const inverse = 1 - progress;
-    const width = collapsedSize + (expandedWidth - collapsedSize) * inverse;
-    const height = collapsedSize + (expandedHeight - collapsedSize) * inverse;
-    const paddingY = expandedPaddingY * inverse;
-    const paddingX = expandedPaddingX * inverse;
-    const gap = expandedGap * inverse;
-    const radius = collapsedRadius * progress + expandedRadius * inverse;
-    const iconSize = collapsedIconSize * progress + expandedIconSize * inverse;
-    const iconShadow = progress > 0.8 ? collapsedIconShadow : expandedIconShadow;
-    const iconBg = progress > 0.8 ? collapsedIconBg : expandedIconBg;
-    const boxShadow = progress > 0.8 ? collapsedShadow : expandedShadow;
-    const justify = progress > 0.75 ? 'center' : expandedJustify;
-    toggle.style.setProperty('--wa-toggle-width', `${width}px`);
-    toggle.style.setProperty('--wa-toggle-height', `${height}px`);
-    toggle.style.setProperty('--wa-toggle-padding-y', `${paddingY}px`);
-    toggle.style.setProperty('--wa-toggle-padding-x', `${paddingX}px`);
-    toggle.style.setProperty('--wa-toggle-gap', `${gap}px`);
-    toggle.style.setProperty('--wa-toggle-radius', `${radius}px`);
-    toggle.style.setProperty('--wa-toggle-justify', justify);
-    toggle.style.boxShadow = boxShadow;
-    toggleIcon.style.setProperty('--wa-toggle-icon-size', `${iconSize}px`);
-    toggleIcon.style.setProperty('--wa-toggle-icon-shadow', iconShadow);
-    toggleIcon.style.setProperty('--wa-toggle-icon-bg', iconBg);
-    const copyOpacity = Math.max(0, Math.min(1, inverse * 1.2));
-    toggle.style.setProperty('--wa-toggle-copy-opacity', copyOpacity.toString());
-    const copyShift = `${-12 * progress}px`;
-    toggle.style.setProperty('--wa-toggle-copy-shift', copyShift);
-    toggle.style.setProperty('--wa-toggle-copy-visibility', progress > 0.98 ? 'hidden' : 'visible');
-    if(toggleCopy){
-      toggleCopy.style.pointerEvents = progress > 0.98 ? 'none' : '';
-    }
-    widget.classList.toggle('is-scrolled', progress > 0.02);
-  };
-
-  const scheduleProgress = (progress) => {
-    pendingProgress = Math.max(0, Math.min(1, progress));
-    if(frameId) return;
-    frameId = requestAnimationFrame(() => {
-      frameId = null;
-      applyProgress(pendingProgress);
-    });
-  };
-
-  const updateScrollState = () => {
-    if(toggle.getAttribute('aria-expanded') === 'true'){
-      scheduleProgress(0);
-      return;
-    }
-    const target = Math.max(0, Math.min(1, window.scrollY / collapseRange));
-    scheduleProgress(target);
-  };
-
-  captureExpandedMetrics();
-
-  const openPanel = () => {
-    if(panel.hasAttribute('data-closing')){
-      panel.removeAttribute('data-closing');
-    }
-    panel.hidden = false;
-    panel.setAttribute('aria-hidden', 'false');
-    requestAnimationFrame(() => {
-      widget.classList.add('is-open');
-      toggle.setAttribute('aria-expanded', 'true');
-      scheduleProgress(0);
-      updateScrollState();
-    });
-  };
-
-  const closePanel = () => {
-    widget.classList.remove('is-open');
-    toggle.setAttribute('aria-expanded', 'false');
-    panel.setAttribute('aria-hidden', 'true');
-    panel.setAttribute('data-closing', 'true');
-    updateScrollState();
-    setTimeout(() => {
-      if(panel.getAttribute('data-closing') === 'true'){
-        panel.hidden = true;
-        panel.removeAttribute('data-closing');
-      }
-    }, 220);
-  };
-
-  toggle.addEventListener('click', () => {
-    const expanded = toggle.getAttribute('aria-expanded') === 'true';
-    if(expanded){
-      closePanel();
-    } else {
-      openPanel();
-    }
-  });
-
-  closeBtn.addEventListener('click', closePanel);
-
-  if(cta){
-    cta.addEventListener('click', () => {
-      closePanel();
-    });
-  }
-
-  document.addEventListener('click', (event) => {
-    if(!widget.contains(event.target) && toggle.getAttribute('aria-expanded') === 'true'){
-      closePanel();
-    }
-  });
-
-  document.addEventListener('keydown', (event) => {
-    if(event.key === 'Escape' && toggle.getAttribute('aria-expanded') === 'true'){
-      closePanel();
-    }
-  });
-
-  window.addEventListener('scroll', updateScrollState, {passive: true});
-  window.addEventListener('resize', () => {
-    const previousProgress = collapseProgress;
-    rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
-    collapsedSize = 3.25 * rootFontSize;
-    collapsedIconSize = 2.4 * rootFontSize;
-    collapsedRadius = collapsedSize / 2;
-    captureExpandedMetrics();
-    scheduleProgress(toggle.getAttribute('aria-expanded') === 'true' ? 0 : previousProgress);
-  });
-  window.addEventListener('load', () => {
-    const previousProgress = collapseProgress;
-    captureExpandedMetrics();
-    scheduleProgress(toggle.getAttribute('aria-expanded') === 'true' ? 0 : previousProgress);
-  });
-  updateScrollState();
-})();
-</script>
+<script src="assets/whatsapp-widget.js"></script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -329,7 +329,13 @@
 <div class="whatsapp-widget" data-wa-link="https://wa.me/94723652618">
   <div class="whatsapp-panel" id="whatsapp-panel" hidden aria-hidden="true">
     <div class="whatsapp-panel__header">
-      <div class="whatsapp-panel__avatar" aria-hidden="true">💬</div>
+      <div class="whatsapp-panel__avatar" aria-hidden="true">
+        <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" focusable="false" role="img" aria-hidden="true">
+          <circle cx="24" cy="24" r="22" fill="#25D366"/>
+          <path d="M24 12c-6.63 0-12 4.94-12 11.03 0 2.62 1.05 5.08 2.89 6.99l-1.2 4.39 4.52-1.18c1.56.43 2.95.6 5.79.6 6.63 0 12-4.94 12-11.03C36 16.94 30.63 12 24 12z" fill="#fff"/>
+          <path d="M19.46 18.24c-.28-.62-.57-.63-.84-.63-.22 0-.45 0-.66 0-.23 0-.6.09-.91.43-.31.34-1.2 1.17-1.2 2.85 0 1.68 1.23 3.3 1.4 3.52.17.22 2.37 3.65 5.87 5.07 2.9 1.2 3.49.96 4.13.9.63-.06 2.03-.82 2.32-1.64.29-.82.29-1.53.2-1.68-.09-.15-.34-.24-.72-.42-.38-.18-2.27-1.11-2.62-1.23-.35-.12-.61-.18-.87.18-.26.36-1 1.23-1.23 1.49-.23.26-.45.28-.83.09-.38-.18-1.61-.59-3.07-1.88-1.14-1.01-1.91-2.26-2.14-2.63-.22-.36-.02-.55.17-.73.17-.17.38-.45.57-.68.18-.23.24-.39.36-.65.12-.26.06-.48-.03-.66-.09-.18-.82-2.01-1.13-2.73z" fill="#128C7E"/>
+        </svg>
+      </div>
       <div class="whatsapp-panel__title">
         <strong>Capital Connect LK</strong>
         <span class="whatsapp-panel__status">We're online</span>
@@ -345,15 +351,9 @@
   <button class="whatsapp-toggle" type="button" aria-expanded="false" aria-controls="whatsapp-panel">
     <span class="toggle-icon" aria-hidden="true">
       <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" role="img" aria-hidden="true">
-        <defs>
-          <linearGradient id="waGradientToggle" x1="8" y1="8" x2="40" y2="40" gradientUnits="userSpaceOnUse">
-            <stop offset="0" stop-color="#25D366"/>
-            <stop offset="1" stop-color="#128C7E"/>
-          </linearGradient>
-        </defs>
-        <circle cx="24" cy="24" r="22" fill="url(#waGradientToggle)"/>
-        <path d="M24 12c-6.63 0-12 4.94-12 11.03 0 2.62 1.05 5.08 2.89 6.99l-1.2 4.39 4.52-1.18c1.56.43 2.95.6 5.79.6 6.63 0 12-4.94 12-11.03C36 16.94 30.63 12 24 12z" fill="#fff" fill-opacity=".98"/>
-        <path d="M19.46 18.24c-.28-.62-.57-.63-.84-.63-.22 0-.45 0-.66 0-.23 0-.6.09-.91.43-.31.34-1.2 1.17-1.2 2.85 0 1.68 1.23 3.3 1.4 3.52.17.22 2.37 3.65 5.87 5.07 2.9 1.2 3.49.96 4.13.9.63-.06 2.03-.82 2.32-1.64.29-.82.29-1.53.2-1.68-.09-.15-.34-.24-.72-.42-.38-.18-2.27-1.11-2.62-1.23-.35-.12-.61-.18-.87.18-.26.36-1 1.23-1.23 1.49-.23.26-.45.28-.83.09-.38-.18-1.61-.59-3.07-1.88-1.14-1.01-1.91-2.26-2.14-2.63-.22-.36-.02-.55.17-.73.17-.17.38-.45.57-.68.18-.23.24-.39.36-.65.12-.26.06-.48-.03-.66-.09-.18-.82-2.01-1.13-2.73z" fill="url(#waGradientToggle)"/>
+        <circle cx="24" cy="24" r="22" fill="#25D366"/>
+        <path d="M24 12c-6.63 0-12 4.94-12 11.03 0 2.62 1.05 5.08 2.89 6.99l-1.2 4.39 4.52-1.18c1.56.43 2.95.6 5.79.6 6.63 0 12-4.94 12-11.03C36 16.94 30.63 12 24 12z" fill="#fff"/>
+        <path d="M19.46 18.24c-.28-.62-.57-.63-.84-.63-.22 0-.45 0-.66 0-.23 0-.6.09-.91.43-.31.34-1.2 1.17-1.2 2.85 0 1.68 1.23 3.3 1.4 3.52.17.22 2.37 3.65 5.87 5.07 2.9 1.2 3.49.96 4.13.9.63-.06 2.03-.82 2.32-1.64.29-.82.29-1.53.2-1.68-.09-.15-.34-.24-.72-.42-.38-.18-2.27-1.11-2.62-1.23-.35-.12-.61-.18-.87.18-.26.36-1 1.23-1.23 1.49-.23.26-.45.28-.83.09-.38-.18-1.61-.59-3.07-1.88-1.14-1.01-1.91-2.26-2.14-2.63-.22-.36-.02-.55.17-.73.17-.17.38-.45.57-.68.18-.23.24-.39.36-.65.12-.26.06-.48-.03-.66-.09-.18-.82-2.01-1.13-2.73z" fill="#128C7E"/>
       </svg>
     </span>
     <span class="toggle-copy">
@@ -363,249 +363,7 @@
   </button>
 </div>
 
-<script>
-(function(){
-  const widget = document.querySelector('.whatsapp-widget');
-  if(!widget) return;
-  const toggle = widget.querySelector('.whatsapp-toggle');
-  const panel = widget.querySelector('.whatsapp-panel');
-  const closeBtn = widget.querySelector('.whatsapp-close');
-  const cta = widget.querySelector('.whatsapp-panel__cta');
-  const toggleIcon = toggle.querySelector('.toggle-icon');
-  const toggleCopy = toggle.querySelector('.toggle-copy');
-  const waLink = widget.getAttribute('data-wa-link');
-
-  if(waLink && cta){
-    cta.setAttribute('href', waLink);
-  }
-
-  const collapseRange = 180;
-  const collapsedShadow = '0 18px 36px rgba(18,140,126,.32)';
-  const collapsedIconShadow = '0 6px 14px rgba(0,0,0,.16)';
-  const collapsedIconBg = 'rgba(255,255,255,.18)';
-  let rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
-  let collapsedSize = 3.25 * rootFontSize;
-  let collapsedIconSize = 2.4 * rootFontSize;
-  let collapsedRadius = collapsedSize / 2;
-  let expandedWidth = 0;
-  let expandedHeight = 0;
-  let expandedPaddingY = 0;
-  let expandedPaddingX = 0;
-  let expandedGap = 0;
-  let expandedRadius = 999;
-  let expandedShadow = getComputedStyle(toggle).boxShadow;
-  let expandedJustify = getComputedStyle(toggle).justifyContent || 'flex-start';
-  let expandedIconSize = 0;
-  let expandedIconShadow = getComputedStyle(toggleIcon).boxShadow;
-  let expandedIconBg = getComputedStyle(toggleIcon).backgroundColor;
-  let collapseProgress = 0;
-  let pendingProgress = 0;
-  let frameId = null;
-
-  const captureExpandedMetrics = () => {
-    const stored = {
-      width: toggle.style.getPropertyValue('--wa-toggle-width'),
-      height: toggle.style.getPropertyValue('--wa-toggle-height'),
-      paddingY: toggle.style.getPropertyValue('--wa-toggle-padding-y'),
-      paddingX: toggle.style.getPropertyValue('--wa-toggle-padding-x'),
-      gap: toggle.style.getPropertyValue('--wa-toggle-gap'),
-      radius: toggle.style.getPropertyValue('--wa-toggle-radius'),
-      justify: toggle.style.getPropertyValue('--wa-toggle-justify'),
-      copyOpacity: toggle.style.getPropertyValue('--wa-toggle-copy-opacity'),
-      copyShift: toggle.style.getPropertyValue('--wa-toggle-copy-shift'),
-      copyVisibility: toggle.style.getPropertyValue('--wa-toggle-copy-visibility'),
-      boxShadow: toggle.style.boxShadow,
-      iconSize: toggleIcon.style.getPropertyValue('--wa-toggle-icon-size'),
-      iconShadow: toggleIcon.style.getPropertyValue('--wa-toggle-icon-shadow'),
-      iconBg: toggleIcon.style.getPropertyValue('--wa-toggle-icon-bg'),
-      pointerEvents: toggleCopy ? toggleCopy.style.pointerEvents : undefined
-    };
-
-    toggle.style.removeProperty('--wa-toggle-width');
-    toggle.style.removeProperty('--wa-toggle-height');
-    toggle.style.removeProperty('--wa-toggle-padding-y');
-    toggle.style.removeProperty('--wa-toggle-padding-x');
-    toggle.style.removeProperty('--wa-toggle-gap');
-    toggle.style.removeProperty('--wa-toggle-radius');
-    toggle.style.removeProperty('--wa-toggle-justify');
-    toggle.style.removeProperty('--wa-toggle-copy-opacity');
-    toggle.style.removeProperty('--wa-toggle-copy-shift');
-    toggle.style.removeProperty('--wa-toggle-copy-visibility');
-    toggle.style.boxShadow = '';
-    toggleIcon.style.removeProperty('--wa-toggle-icon-size');
-    toggleIcon.style.removeProperty('--wa-toggle-icon-shadow');
-    toggleIcon.style.removeProperty('--wa-toggle-icon-bg');
-    if(toggleCopy){
-      toggleCopy.style.pointerEvents = '';
-    }
-
-    const toggleStyles = getComputedStyle(toggle);
-    const iconStyles = getComputedStyle(toggleIcon);
-    expandedJustify = toggleStyles.justifyContent || 'flex-start';
-    expandedShadow = toggleStyles.boxShadow;
-    expandedGap = parseFloat(toggleStyles.columnGap || toggleStyles.gap) || 0;
-    expandedPaddingY = parseFloat(toggleStyles.paddingTop) || 0;
-    expandedPaddingX = parseFloat(toggleStyles.paddingLeft) || 0;
-    expandedRadius = parseFloat(toggleStyles.borderTopLeftRadius) || 999;
-    const rect = toggle.getBoundingClientRect();
-    expandedWidth = rect.width;
-    expandedHeight = rect.height;
-    const iconRect = toggleIcon.getBoundingClientRect();
-    expandedIconSize = iconRect.width;
-    expandedIconShadow = iconStyles.boxShadow;
-    expandedIconBg = iconStyles.backgroundColor;
-
-    if(stored.width) toggle.style.setProperty('--wa-toggle-width', stored.width);
-    if(stored.height) toggle.style.setProperty('--wa-toggle-height', stored.height);
-    if(stored.paddingY) toggle.style.setProperty('--wa-toggle-padding-y', stored.paddingY);
-    if(stored.paddingX) toggle.style.setProperty('--wa-toggle-padding-x', stored.paddingX);
-    if(stored.gap) toggle.style.setProperty('--wa-toggle-gap', stored.gap);
-    if(stored.radius) toggle.style.setProperty('--wa-toggle-radius', stored.radius);
-    if(stored.justify) toggle.style.setProperty('--wa-toggle-justify', stored.justify);
-    if(stored.copyOpacity) toggle.style.setProperty('--wa-toggle-copy-opacity', stored.copyOpacity);
-    if(stored.copyShift) toggle.style.setProperty('--wa-toggle-copy-shift', stored.copyShift);
-    if(stored.copyVisibility) toggle.style.setProperty('--wa-toggle-copy-visibility', stored.copyVisibility);
-    if(stored.boxShadow) toggle.style.boxShadow = stored.boxShadow;
-    if(stored.iconSize) toggleIcon.style.setProperty('--wa-toggle-icon-size', stored.iconSize);
-    if(stored.iconShadow) toggleIcon.style.setProperty('--wa-toggle-icon-shadow', stored.iconShadow);
-    if(stored.iconBg) toggleIcon.style.setProperty('--wa-toggle-icon-bg', stored.iconBg);
-    if(toggleCopy && stored.pointerEvents !== undefined){
-      toggleCopy.style.pointerEvents = stored.pointerEvents;
-    }
-  };
-
-  const applyProgress = (progress) => {
-    collapseProgress = progress;
-    widget.style.setProperty('--wa-collapse-progress', progress.toFixed(3));
-    const inverse = 1 - progress;
-    const width = collapsedSize + (expandedWidth - collapsedSize) * inverse;
-    const height = collapsedSize + (expandedHeight - collapsedSize) * inverse;
-    const paddingY = expandedPaddingY * inverse;
-    const paddingX = expandedPaddingX * inverse;
-    const gap = expandedGap * inverse;
-    const radius = collapsedRadius * progress + expandedRadius * inverse;
-    const iconSize = collapsedIconSize * progress + expandedIconSize * inverse;
-    const iconShadow = progress > 0.8 ? collapsedIconShadow : expandedIconShadow;
-    const iconBg = progress > 0.8 ? collapsedIconBg : expandedIconBg;
-    const boxShadow = progress > 0.8 ? collapsedShadow : expandedShadow;
-    const justify = progress > 0.75 ? 'center' : expandedJustify;
-    toggle.style.setProperty('--wa-toggle-width', `${width}px`);
-    toggle.style.setProperty('--wa-toggle-height', `${height}px`);
-    toggle.style.setProperty('--wa-toggle-padding-y', `${paddingY}px`);
-    toggle.style.setProperty('--wa-toggle-padding-x', `${paddingX}px`);
-    toggle.style.setProperty('--wa-toggle-gap', `${gap}px`);
-    toggle.style.setProperty('--wa-toggle-radius', `${radius}px`);
-    toggle.style.setProperty('--wa-toggle-justify', justify);
-    toggle.style.boxShadow = boxShadow;
-    toggleIcon.style.setProperty('--wa-toggle-icon-size', `${iconSize}px`);
-    toggleIcon.style.setProperty('--wa-toggle-icon-shadow', iconShadow);
-    toggleIcon.style.setProperty('--wa-toggle-icon-bg', iconBg);
-    const copyOpacity = Math.max(0, Math.min(1, inverse * 1.2));
-    toggle.style.setProperty('--wa-toggle-copy-opacity', copyOpacity.toString());
-    const copyShift = `${-12 * progress}px`;
-    toggle.style.setProperty('--wa-toggle-copy-shift', copyShift);
-    toggle.style.setProperty('--wa-toggle-copy-visibility', progress > 0.98 ? 'hidden' : 'visible');
-    if(toggleCopy){
-      toggleCopy.style.pointerEvents = progress > 0.98 ? 'none' : '';
-    }
-    widget.classList.toggle('is-scrolled', progress > 0.02);
-  };
-
-  const scheduleProgress = (progress) => {
-    pendingProgress = Math.max(0, Math.min(1, progress));
-    if(frameId) return;
-    frameId = requestAnimationFrame(() => {
-      frameId = null;
-      applyProgress(pendingProgress);
-    });
-  };
-
-  const updateScrollState = () => {
-    if(toggle.getAttribute('aria-expanded') === 'true'){
-      scheduleProgress(0);
-      return;
-    }
-    const target = Math.max(0, Math.min(1, window.scrollY / collapseRange));
-    scheduleProgress(target);
-  };
-
-  captureExpandedMetrics();
-
-  const openPanel = () => {
-    if(panel.hasAttribute('data-closing')){
-      panel.removeAttribute('data-closing');
-    }
-    panel.hidden = false;
-    panel.setAttribute('aria-hidden', 'false');
-    requestAnimationFrame(() => {
-      widget.classList.add('is-open');
-      toggle.setAttribute('aria-expanded', 'true');
-      scheduleProgress(0);
-      updateScrollState();
-    });
-  };
-
-  const closePanel = () => {
-    widget.classList.remove('is-open');
-    toggle.setAttribute('aria-expanded', 'false');
-    panel.setAttribute('aria-hidden', 'true');
-    panel.setAttribute('data-closing', 'true');
-    updateScrollState();
-    setTimeout(() => {
-      if(panel.getAttribute('data-closing') === 'true'){
-        panel.hidden = true;
-        panel.removeAttribute('data-closing');
-      }
-    }, 220);
-  };
-
-  toggle.addEventListener('click', () => {
-    const expanded = toggle.getAttribute('aria-expanded') === 'true';
-    if(expanded){
-      closePanel();
-    } else {
-      openPanel();
-    }
-  });
-
-  closeBtn.addEventListener('click', closePanel);
-
-  if(cta){
-    cta.addEventListener('click', () => {
-      closePanel();
-    });
-  }
-
-  document.addEventListener('click', (event) => {
-    if(!widget.contains(event.target) && toggle.getAttribute('aria-expanded') === 'true'){
-      closePanel();
-    }
-  });
-
-  document.addEventListener('keydown', (event) => {
-    if(event.key === 'Escape' && toggle.getAttribute('aria-expanded') === 'true'){
-      closePanel();
-    }
-  });
-
-  window.addEventListener('scroll', updateScrollState, {passive: true});
-  window.addEventListener('resize', () => {
-    const previousProgress = collapseProgress;
-    rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
-    collapsedSize = 3.25 * rootFontSize;
-    collapsedIconSize = 2.4 * rootFontSize;
-    collapsedRadius = collapsedSize / 2;
-    captureExpandedMetrics();
-    scheduleProgress(toggle.getAttribute('aria-expanded') === 'true' ? 0 : previousProgress);
-  });
-  window.addEventListener('load', () => {
-    const previousProgress = collapseProgress;
-    captureExpandedMetrics();
-    scheduleProgress(toggle.getAttribute('aria-expanded') === 'true' ? 0 : previousProgress);
-  });
-  updateScrollState();
-})();
-</script>
+<script src="assets/whatsapp-widget.js"></script>
 
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -195,6 +195,7 @@ hr.sep{border:0;border-top:1px solid #e6eaee;margin:1.75rem 0}
 .whatsapp-widget.is-open .whatsapp-panel{opacity:1;transform:translateY(0) scale(1);pointer-events:auto}
 .whatsapp-panel__header{display:flex;align-items:flex-start;gap:.8rem;padding:1rem 1.1rem 0 1.1rem}
 .whatsapp-panel__avatar{width:44px;height:44px;border-radius:14px;background:rgba(255,255,255,.2);display:grid;place-items:center;font-size:1.35rem;box-shadow:0 12px 20px rgba(10,20,30,.22)}
+.whatsapp-panel__avatar svg{width:26px;height:26px;display:block}
 .whatsapp-panel__title{display:grid;gap:.25rem}
 .whatsapp-panel__title strong{font-size:1rem;letter-spacing:-.01em}
 .whatsapp-panel__status{font-size:.78rem;text-transform:uppercase;letter-spacing:.08em;color:rgba(244,255,248,.78);font-weight:600}


### PR DESCRIPTION
## Summary
- replace the WhatsApp toggle and panel artwork with the flat brand icon and size it consistently in both pages
- extract the widget interactions into `assets/whatsapp-widget.js` and update the scroll handling so the toggle stays aligned and skips collapsing on small screens
- reference the shared script from the landing and contact pages to keep the CTA link behaviour intact

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d9ed7b868c8325b510d4ebed92a864