### PR TITLE
Fix WhatsApp toggle collapse alignment

### DIFF
--- a/assets/whatsapp-widget.js
+++ b/assets/whatsapp-widget.js
@@ -58,6 +58,7 @@
     toggleIcon.style.removeProperty('--wa-toggle-icon-bg');
     if(toggleCopy){
       toggleCopy.style.pointerEvents = '';
+      toggleCopy.style.display = '';
     }
   }
 
@@ -157,7 +158,9 @@
     toggle.style.setProperty('--wa-toggle-copy-shift', copyShift);
     toggle.style.setProperty('--wa-toggle-copy-visibility', progress > 0.98 ? 'hidden' : 'visible');
     if(toggleCopy){
-      toggleCopy.style.pointerEvents = progress > 0.98 ? 'none' : '';
+      const shouldHideCopy = progress > 0.98;
+      toggleCopy.style.pointerEvents = shouldHideCopy ? 'none' : '';
+      toggleCopy.style.display = shouldHideCopy ? 'none' : '';
     }
     widget.classList.toggle('is-scrolled', progress > 0.02);
   }


### PR DESCRIPTION
## Summary
- ensure the WhatsApp widget removes the text block from layout when collapsed so the icon stays centered in the circle

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68da3318d2388325b95a5113c31b5b06