### PR TITLE
Add interactive liquid animation to Request a Call buttons

### DIFF
--- a/assets/liquid-button.js
+++ b/assets/liquid-button.js
@@ -1,0 +1,56 @@
+(() => {
+  const buttons = Array.from(document.querySelectorAll('.btn'));
+  if (!buttons.length) return;
+
+  const PROXIMITY = 180;
+
+  const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+  function resetButton(button) {
+    button.classList.remove('is-near');
+    button.style.removeProperty('--tilt-x');
+    button.style.removeProperty('--tilt-y');
+    button.style.removeProperty('--liquid-x');
+    button.style.removeProperty('--liquid-y');
+    button.style.removeProperty('--liquid-intensity');
+  }
+
+  function handlePointerMove(event) {
+    const { clientX, clientY } = event;
+
+    buttons.forEach((button) => {
+      const rect = button.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+      const deltaX = clientX - centerX;
+      const deltaY = clientY - centerY;
+      const distance = Math.hypot(deltaX, deltaY);
+      const proximity = Math.max(0, Math.min(1, 1 - distance / PROXIMITY));
+
+      if (proximity <= 0.01) {
+        resetButton(button);
+        return;
+      }
+
+      const localX = clamp(clientX - rect.left, 0, rect.width);
+      const localY = clamp(clientY - rect.top, 0, rect.height);
+
+      button.style.setProperty('--tilt-x', `${deltaX * 0.08 * proximity}px`);
+      button.style.setProperty('--tilt-y', `${deltaY * 0.08 * proximity}px`);
+      button.style.setProperty('--liquid-x', `${localX}px`);
+      button.style.setProperty('--liquid-y', `${localY}px`);
+      button.style.setProperty('--liquid-intensity', proximity.toFixed(3));
+      button.classList.add('is-near');
+    });
+  }
+
+  function handlePointerOut(event) {
+    if (event.relatedTarget === null) {
+      buttons.forEach(resetButton);
+    }
+  }
+
+  window.addEventListener('pointermove', handlePointerMove, { passive: true });
+  window.addEventListener('pointerout', handlePointerOut);
+  window.addEventListener('scroll', () => buttons.forEach(resetButton), { passive: true });
+})();

--- a/contact.html
+++ b/contact.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Capital Connect LK</title>
 <link rel="stylesheet" href="styles.css">
+<script src="assets/liquid-button.js" defer></script>
 <style>
 .form-wrap{position:relative;border-radius:32px;border:1px solid rgba(255,255,255,.55);background:rgba(255,255,255,.35);backdrop-filter:saturate(180%) blur(32px);box-shadow:0 40px 80px rgba(15,23,42,.22);overflow:hidden;isolation:isolate}
 .form-wrap::before,.form-wrap::after{content:"";position:absolute;inset:auto;border-radius:999px;filter:blur(40px);opacity:.65;pointer-events:none;mix-blend-mode:screen}

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 <meta name="description" content="Transform underutilized rooftops into income-generating assets through a seamless, hassle-free process." />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="styles.css">
+<script src="assets/liquid-button.js" defer></script>
 </head>
 <body>
 

--- a/styles.css
+++ b/styles.css
@@ -55,10 +55,18 @@ img{max-width:100%;display:block}
 .btn{display:inline-flex;align-items:center;gap:.5rem;
   background:var(--cta);color:var(--cta-ink);border-radius:999px;padding:.72rem 1.2rem;
   font-weight:600; box-shadow:0 18px 28px rgba(10,132,255,.28), 0 0 0 1px rgba(255,255,255,.3) inset;
-  border:0; position:relative; overflow:hidden;transition:transform .4s cubic-bezier(.25,.8,.25,1),box-shadow .4s;
+  border:0; position:relative; overflow:hidden;transition:transform .4s cubic-bezier(.25,.8,.25,1),box-shadow .4s,background .4s;
+  --tilt-x:0px;--tilt-y:0px;--liquid-x:50%;--liquid-y:50%;--liquid-intensity:0;
+  transform:translate3d(var(--tilt-x),var(--tilt-y),0);
 }
-.btn::after{content:"";position:absolute;inset:2px;border-radius:999px;background:linear-gradient(135deg,rgba(255,255,255,.28),rgba(255,255,255,0));opacity:0;transition:opacity .3s ease;}
-.btn:hover{transform:translateY(-2px) scale(1.01);box-shadow:0 26px 40px rgba(10,132,255,.3);
+.btn::before{content:"";position:absolute;inset:-35%;border-radius:50%;
+  background:radial-gradient(120% 160% at var(--liquid-x) var(--liquid-y),rgba(255,255,255,.55),rgba(90,200,250,.32) 45%,rgba(10,132,255,0) 75%);
+  opacity:calc(var(--liquid-intensity) * .9);transition:opacity .35s ease;pointer-events:none;mix-blend-mode:screen;
+}
+.btn::after{content:"";position:absolute;inset:2px;border-radius:999px;background:linear-gradient(135deg,rgba(255,255,255,.28),rgba(255,255,255,0));opacity:0;transition:opacity .3s ease;pointer-events:none;}
+.btn.is-near{box-shadow:0 24px 44px rgba(10,132,255,.32),0 0 0 1px rgba(255,255,255,.38) inset;}
+.btn.is-near::after{opacity:.5;}
+.btn:hover{transform:translate3d(var(--tilt-x),calc(var(--tilt-y) - 2px),0) scale(1.01);box-shadow:0 26px 40px rgba(10,132,255,.3);
 }
 .btn:hover::after{opacity:1}
 .btn:focus-visible{outline:2px solid rgba(10,132,255,.55);outline-offset:3px}


### PR DESCRIPTION
## Summary
- add a reusable script that tracks pointer proximity to buttons and updates CSS variables for a fluid animation
- extend the button styling with liquid gradient and proximity states for the call-to-action buttons
- include the script on the landing and contact pages so every Request a Call button gains the interactive effect

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da3ba1409c832596ad136afe566a9b