### PR TITLE
Use official logo in site header and footer

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -60,7 +60,7 @@ background-size:7px 7px,7px 7px}
 <header class="header">
   <div class="container header-inner">
     <div class="logo">
-      <span class="logo-placeholder" role="img" aria-label="Capital Connect LK"></span>
+      <img src="logo.png" alt="Capital Connect LK logo" class="logo-image">
       <span class="site-title">Capital Connect LK</span>
     </div>
     <nav>
@@ -78,7 +78,7 @@ background-size:7px 7px,7px 7px}
     <div class="form-wrap">
       <div class="form-head">
         <div class="logo">
-          <span class="logo-placeholder" role="img" aria-label="Capital Connect LK"></span>
+          <img src="logo.png" alt="Capital Connect LK logo" class="logo-image">
           <span class="site-title">Capital Connect LK</span>
         </div>
         <a class="btn small" href="#">Request a Call</a>
@@ -143,7 +143,7 @@ background-size:7px 7px,7px 7px}
 <footer id="footer" class="footer">
   <div class="container inner">
     <div class="logo">
-      <span class="logo-placeholder" role="img" aria-label="Capital Connect LK"></span>
+      <img src="logo.png" alt="Capital Connect LK logo" class="logo-image">
       <span class="site-title">Capital Connect LK</span>
     </div>
     <div>Curated introductions. No upfront fees.</div>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 <header class="header">
   <div class="container header-inner">
     <div class="logo">
-      <span class="logo-placeholder" role="img" aria-label="Capital Connect LK"></span>
+      <img src="logo.png" alt="Capital Connect LK logo" class="logo-image">
       <span class="site-title">Capital Connect LK</span>
     </div>
     <nav>
@@ -317,7 +317,7 @@
 <footer id="footer" class="footer">
   <div class="container inner">
     <div class="logo">
-      <span class="logo-placeholder" role="img" aria-label="Capital Connect LK"></span>
+      <img src="logo.png" alt="Capital Connect LK logo" class="logo-image">
       <span class="site-title">Capital Connect LK</span>
     </div>
     <div>Curated introductions. No upfront fees.</div>

--- a/styles.css
+++ b/styles.css
@@ -50,7 +50,7 @@ img{max-width:100%;display:block}
 }
 .header-inner{display:flex;align-items:center;justify-content:space-between; padding:.85rem 1.2rem; gap:1.4rem}
 .logo{display:flex;align-items:center;gap:.65rem;font-weight:700;letter-spacing:-.01em;color:var(--ink)}
-.logo-placeholder{width:32px;height:32px;border-radius:10px;background:#000;box-shadow:0 10px 22px rgba(15,23,42,.24);display:block}
+.logo-image{width:36px;height:36px;border-radius:10px;box-shadow:0 10px 22px rgba(15,23,42,.24);display:block;object-fit:contain;background:#fff;padding:4px}
 .site-title{font-size:1.05rem}
 .btn{display:inline-flex;align-items:center;gap:.5rem;
   background:var(--cta);color:var(--cta-ink);border-radius:999px;padding:.72rem 1.2rem;


### PR DESCRIPTION
## Summary
- replace the temporary placeholder element with the official Capital Connect LK logo in the navigation headers and footers
- add styling so the logo image keeps a consistent size and framing across the site

## Testing
- not run (static content only)

------
https://chatgpt.com/codex/tasks/task_e_68da457667d48325a1cd77a1d0bce45f