### PR TITLE
Adjust feature icons to circular badges

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -169,8 +169,21 @@ h2{font-size:clamp(1.4rem, 1.3vw + 1.2rem, 2.1rem); margin:0 0 .85rem;font-weigh
 .about-feature{display:flex;gap:1rem;align-items:flex-start;padding:1.2rem;border-radius:20px;background:linear-gradient(140deg,rgba(255,255,255,.78),rgba(255,255,255,.48));border:1px solid rgba(255,255,255,.55);backdrop-filter:blur(22px);box-shadow:0 26px 46px rgba(15,23,42,.14);transition:transform .35s ease, box-shadow .35s ease}
 .about-feature:hover{transform:translateY(-4px);box-shadow:0 34px 58px rgba(10,20,60,.18)}
 .about-feature h3{margin:0;font-size:1.05rem;letter-spacing:-.01em}
-.feature-icon{width:46px;height:46px;border-radius:50%;display:grid;place-items:center;font-size:1.3rem;background:linear-gradient(135deg,rgba(10,132,255,.22),rgba(90,200,250,.22));border:1px solid rgba(10,132,255,.28);box-shadow:0 12px 26px rgba(10,132,255,.18)}
-.feature-icon svg{width:26px;height:26px;display:block}
+.feature-icon{
+  width:58px;
+  aspect-ratio:1/1;
+  border-radius:50%;
+  display:grid;
+  place-items:center;
+  background:linear-gradient(135deg,rgba(10,132,255,.18),rgba(90,200,250,.28));
+  border:1.5px solid rgba(10,132,255,.35);
+  box-shadow:0 14px 30px rgba(10,132,255,.22);
+}
+.feature-icon svg{
+  width:60%;
+  height:60%;
+  display:block;
+}
 .about-side{position:sticky;top:6.5rem;display:grid;gap:1rem;padding:2rem}
 .about-side h3{margin:0;font-size:1.35rem}
 .about-side .caption{color:rgba(15,23,42,.75)}


### PR DESCRIPTION
## Summary
- restyle the about-section feature icon container to render as consistent circular badges
- scale down the SVG footprint so the artwork sits neatly inside the new circle treatment

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68da49a1418c832595a9321efb6cc353