### PR TITLE
Refine hero ZERO highlight shadows

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -106,8 +106,7 @@ h1{font-size:clamp(2.1rem, 2.6vw + 1.4rem, 3.2rem);line-height:1.08;margin:.6rem
   -webkit-background-clip:text;
   background-clip:text;
   animation:liquidDrift 6s ease-in-out infinite;
-  filter:drop-shadow(0 0 18px rgba(10,120,255,.48)) drop-shadow(0 22px 38px rgba(10,20,60,.22));
-  text-shadow:0 0 18px rgba(10,180,255,.6),0 0 32px rgba(0,112,255,.35);
+  filter:drop-shadow(0 18px 32px rgba(10,20,60,.18));
 }
 @keyframes liquidDrift{
   0%{background-position:0% 50%,0% 50%;}


### PR DESCRIPTION
## Summary
- remove the text glow from the hero ZERO highlight by eliminating the text-shadow
- simplify the highlight's filter to a single, softer drop-shadow for subtler depth

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da5319e3f88325a55b4c3cec8c89e7