### PR TITLE
Fix logo image paths and add favicon

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Capital Connect LK</title>
 <link rel="stylesheet" href="styles.css">
+<link rel="icon" type="image/png" href="logo.png">
 <script src="assets/liquid-button.js" defer></script>
 <style>
 .form-wrap{position:relative;border-radius:32px;border:1px solid rgba(255,255,255,.55);background:rgba(255,255,255,.35);backdrop-filter:saturate(180%) blur(32px);box-shadow:0 40px 80px rgba(15,23,42,.22);overflow:hidden;isolation:isolate}
@@ -60,7 +61,7 @@ background-size:7px 7px,7px 7px}
 <header class="header">
   <div class="container header-inner">
     <div class="logo">
-      <img src="https://github.com/Dulanpasindu99/capitalconectlkweb/blob/main/logo.png" alt="Capital Connect LK logo" class="logo-image">
+      <img src="logo.png" alt="Capital Connect LK logo" class="logo-image">
       <span class="site-title">Capital Connect LK</span>
     </div>
     <nav>
@@ -78,7 +79,7 @@ background-size:7px 7px,7px 7px}
     <div class="form-wrap">
       <div class="form-head">
         <div class="logo">
-          <img src="https://github.com/Dulanpasindu99/capitalconectlkweb/blob/main/logo.png" alt="Capital Connect LK logo" class="logo-image">
+          <img src="logo.png" alt="Capital Connect LK logo" class="logo-image">
           <span class="site-title">Capital Connect LK</span>
         </div>
         <a class="btn small" href="#" data-cta="request-call">Request a Call</a>
@@ -143,7 +144,7 @@ background-size:7px 7px,7px 7px}
 <footer id="footer" class="footer">
   <div class="container inner">
     <div class="logo">
-      <img src="https://github.com/Dulanpasindu99/capitalconectlkweb/blob/main/logo.png" alt="Capital Connect LK logo" class="logo-image">
+      <img src="logo.png" alt="Capital Connect LK logo" class="logo-image">
       <span class="site-title">Capital Connect LK</span>
     </div>
     <div>Curated introductions. No upfront fees.</div>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 <meta name="description" content="Transform underutilized rooftops into income-generating assets through a seamless, hassle-free process." />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="styles.css">
+<link rel="icon" type="image/png" href="logo.png">
 <script src="assets/liquid-button.js" defer></script>
 <script src="assets/liquid-banner.js" defer></script>
 </head>
@@ -15,7 +16,7 @@
 <header class="header">
   <div class="container header-inner">
     <div class="logo">
-      <img src="https://github.com/Dulanpasindu99/capitalconectlkweb/blob/main/logo.png" alt="Capital Connect LK logo" class="logo-image">
+      <img src="logo.png" alt="Capital Connect LK logo" class="logo-image">
       <span class="site-title">Capital Connect LK</span>
     </div>
     <nav>


### PR DESCRIPTION
## Summary
- add the logo as the favicon on the marketing and contact pages
- point all logo image references to the local asset instead of the remote GitHub blob

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da5abda3e883258692ab49ca31f216