### PR TITLE
Enable WhatsApp widget collapse on mobile

### DIFF
--- a/assets/whatsapp-widget.js
+++ b/assets/whatsapp-widget.js
@@ -38,7 +38,7 @@
   let frameId = null;
 
   const collapseQuery = window.matchMedia('(max-width: 640px)');
-  let collapseActive = !collapseQuery.matches;
+  let collapseActive = collapseQuery.matches;
 
   function clearProgressStyles(){
     widget.style.removeProperty('--wa-collapse-progress');
@@ -188,7 +188,7 @@
   }
 
   function syncCollapseMode(){
-    collapseActive = !collapseQuery.matches;
+    collapseActive = collapseQuery.matches;
     if(!collapseActive){
       collapseProgress = 0;
       pendingProgress = 0;


### PR DESCRIPTION
## Summary
- activate the WhatsApp floating button collapse/expand animation for mobile viewports by toggling the media query logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68decb7587008325ab7f1b0c59f424f6